### PR TITLE
feat(navigation): add declarative Router with path parameters 

### DIFF
--- a/pkg/navigation/deeplink_router.go
+++ b/pkg/navigation/deeplink_router.go
@@ -15,6 +15,18 @@ type DeepLinkRoute struct {
 }
 
 // DeepLinkController listens for deep links and navigates to matching routes.
+//
+// Deep links are dispatched via [RootNavigator], which requires a [Router] or
+// [Navigator] with IsRoot=true to be present in the widget tree. If your app
+// uses [TabScaffold] at the top level, wrap it in a Router or Navigator:
+//
+//	navigation.Router{
+//	    Routes: []navigation.RouteConfigurer{
+//	        navigation.RouteConfig{Path: "/", Builder: buildTabScaffold},
+//	    },
+//	}
+//
+// Without a root navigator, deep links will remain pending indefinitely.
 type DeepLinkController struct {
 	RouteForLink func(link platform.DeepLink) (DeepLinkRoute, bool)
 	OnError      func(err error)
@@ -103,7 +115,7 @@ func (c *DeepLinkController) handleError(err error) {
 }
 
 func (c *DeepLinkController) navigate(route DeepLinkRoute) {
-	if nav := GlobalNavigator(); nav != nil {
+	if nav := RootNavigator(); nav != nil {
 		nav.PushNamed(route.Name, route.Args)
 		return
 	}
@@ -127,7 +139,7 @@ func (c *DeepLinkController) flushPending() {
 	if pending == nil {
 		return
 	}
-	if nav := GlobalNavigator(); nav != nil {
+	if nav := RootNavigator(); nav != nil {
 		nav.PushNamed(pending.Name, pending.Args)
 		c.mu.Lock()
 		c.pendingRoute = nil

--- a/pkg/navigation/navigator.go
+++ b/pkg/navigation/navigator.go
@@ -9,34 +9,166 @@ import (
 	"github.com/go-drift/drift/pkg/widgets"
 )
 
-// Global navigator for back button handling.
-var (
-	globalNavigator   NavigatorState
-	globalNavigatorMu sync.Mutex
-)
+// NavigationScope tracks navigator hierarchy and determines which navigator
+// receives back button events and deep links.
+//
+// In apps with multiple navigators (e.g., [TabScaffold] with per-tab stacks),
+// NavigationScope ensures the correct navigator handles user input:
+//
+//   - The root navigator (IsRoot=true) handles deep links
+//   - The active navigator (set by TabScaffold on tab change) handles back button
+//   - When the active navigator can't pop, falls back to root
+//
+// You typically don't interact with NavigationScope directly. It's managed
+// automatically by [Navigator] and [TabScaffold].
+type NavigationScope struct {
+	mu              sync.Mutex
+	root            NavigatorState
+	activeNavigator NavigatorState
+}
 
-// HandleBackButton attempts to pop the active navigator.
-// Returns true if handled (route popped), false if at root.
+var globalScope = &NavigationScope{}
+
+// SetRoot registers the root navigator (called by Navigator with IsRoot=true).
+func (s *NavigationScope) SetRoot(nav NavigatorState) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.root = nav
+	if s.activeNavigator == nil {
+		s.activeNavigator = nav
+	}
+}
+
+// SetActiveNavigator sets which navigator receives back button events.
+// TabScaffold calls this on tab change.
+func (s *NavigationScope) SetActiveNavigator(nav NavigatorState) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.activeNavigator = nav
+}
+
+// ActiveNavigator returns the currently focused navigator.
+func (s *NavigationScope) ActiveNavigator() NavigatorState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.activeNavigator != nil {
+		return s.activeNavigator
+	}
+	return s.root
+}
+
+// ClearActiveIf clears activeNavigator if it matches nav (call in Dispose).
+func (s *NavigationScope) ClearActiveIf(nav NavigatorState) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.activeNavigator == nav {
+		s.activeNavigator = s.root // Fall back to root
+	}
+}
+
+// ClearRootIf clears root navigator if it matches nav (call in Dispose).
+func (s *NavigationScope) ClearRootIf(nav NavigatorState) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.root == nav {
+		s.root = nil
+	}
+	if s.activeNavigator == nav {
+		s.activeNavigator = nil
+	}
+}
+
+// HandleBackButton attempts to pop the active navigator's route stack.
+//
+// Call this from platform back button handlers. It tries the active navigator
+// first (e.g., the current tab's navigator), then falls back to the root
+// navigator if the active one can't pop.
+//
+// Returns true if a route was popped, false if at root (app should exit).
+//
+//	// In platform back button handler:
+//	if !navigation.HandleBackButton() {
+//	    // At root - exit app or show confirmation
+//	}
 func HandleBackButton() bool {
-	globalNavigatorMu.Lock()
-	nav := globalNavigator
-	globalNavigatorMu.Unlock()
+	globalScope.mu.Lock()
+	nav := globalScope.activeNavigator
+	root := globalScope.root
+	globalScope.mu.Unlock()
 
 	if nav == nil {
 		return false
 	}
-	return nav.MaybePop(nil)
+
+	// Try active navigator first
+	if nav.CanPop() {
+		return nav.MaybePop(nil)
+	}
+
+	// Only fall back to root if:
+	// 1. Active is different from root (nested navigator)
+	// 2. Root can actually pop
+	// This prevents accidentally popping a parent flow when tab is at root
+	if nav != root && root != nil && root.CanPop() {
+		return root.MaybePop(nil)
+	}
+
+	return false
 }
 
-// GlobalNavigator returns the active navigator, if any.
-func GlobalNavigator() NavigatorState {
-	globalNavigatorMu.Lock()
-	nav := globalNavigator
-	globalNavigatorMu.Unlock()
-	return nav
+// RootNavigator returns the root navigator registered with IsRoot=true.
+//
+// Use this for deep links and external navigation that should always target
+// the main app navigator, regardless of which tab or nested navigator is
+// currently active.
+//
+//	// In a deep link handler:
+//	if nav := navigation.RootNavigator(); nav != nil {
+//	    nav.PushNamed("/product", map[string]any{"id": productID})
+//	}
+//
+// Returns nil if no root navigator has been registered.
+func RootNavigator() NavigatorState {
+	globalScope.mu.Lock()
+	defer globalScope.mu.Unlock()
+	return globalScope.root
 }
 
-// Navigator manages a stack of routes.
+// Navigator manages a stack of routes using imperative navigation.
+//
+// Navigator provides push/pop stack semantics similar to mobile navigation
+// patterns. For declarative route configuration, see [Router] instead.
+//
+// Basic usage:
+//
+//	navigation.Navigator{
+//	    InitialRoute: "/",
+//	    IsRoot:       true, // Required for back button handling
+//	    OnGenerateRoute: func(settings navigation.RouteSettings) navigation.Route {
+//	        switch settings.Name {
+//	        case "/":
+//	            return navigation.NewMaterialPageRoute(buildHome, settings)
+//	        case "/details":
+//	            return navigation.NewMaterialPageRoute(buildDetails, settings)
+//	        }
+//	        return nil
+//	    },
+//	}
+//
+// With route guards for authentication:
+//
+//	navigation.Navigator{
+//	    InitialRoute:      "/",
+//	    IsRoot:            true,
+//	    RefreshListenable: authState, // Re-evaluate on auth changes
+//	    Redirect: func(ctx navigation.RedirectContext) navigation.RedirectResult {
+//	        if !authState.IsLoggedIn() && isProtectedRoute(ctx.ToPath) {
+//	            return navigation.RedirectTo("/login")
+//	        }
+//	        return navigation.NoRedirect()
+//	    },
+//	    OnGenerateRoute: generateRoute,
+//	}
 type Navigator struct {
 	// InitialRoute is the name of the first route to display.
 	InitialRoute string
@@ -49,6 +181,20 @@ type Navigator struct {
 
 	// Observers receive navigation events.
 	Observers []NavigatorObserver
+
+	// IsRoot marks this as the app's primary navigator.
+	// Only root navigators register with the NavigationScope for back button handling.
+	// Set this to true for your main navigator, false for nested navigators (e.g., in tabs).
+	IsRoot bool
+
+	// Redirect is called before every navigation.
+	// Return NoRedirect() to allow navigation, or RedirectTo()/RedirectWithArgs() to redirect.
+	// Only applies to named routes (Push with non-empty Settings().Name, PushNamed, etc.).
+	Redirect func(ctx RedirectContext) RedirectResult
+
+	// RefreshListenable triggers redirect re-evaluation when notified.
+	// Use this when auth state changes to re-check if the current route is still accessible.
+	RefreshListenable core.Listenable
 }
 
 // CreateElement returns a StatefulElement for this Navigator.
@@ -66,38 +212,61 @@ func (n Navigator) CreateState() core.State {
 	return &navigatorState{}
 }
 
-// NavigatorState is the mutable state for a Navigator.
+// NavigatorState provides methods to manipulate the navigation stack.
+//
+// Obtain a NavigatorState using [NavigatorOf] from within the widget tree,
+// or [RootNavigator] from outside it (e.g., for deep links).
+//
+//	nav := navigation.NavigatorOf(ctx)
+//	nav.PushNamed("/details", map[string]any{"id": 123})
 type NavigatorState interface {
-	// Push adds a route to the stack.
+	// Push adds a route to the top of the stack.
+	// If a Redirect callback is configured and the route has a name,
+	// the redirect logic is applied before pushing.
 	Push(route Route)
 
-	// PushNamed pushes a route by name.
+	// PushNamed creates and pushes a route by name.
+	// The route is created via OnGenerateRoute with the given name and args.
+	// Redirect logic is applied if configured.
 	PushNamed(name string, args any)
 
-	// PushReplacementNamed replaces the current route by name
+	// PushReplacementNamed replaces the current route with a new named route.
+	// The old route receives DidPop, the new route receives DidPush.
+	// Redirect logic is applied if configured.
 	PushReplacementNamed(name string, args any)
 
-	// Pop removes the current route and optionally returns a result.
+	// Pop removes the current route from the stack.
+	// The result is passed to the popped route's DidPop callback.
+	// Does nothing if only one route remains (can't pop the root).
 	Pop(result any)
 
-	// PopUntil removes routes until the predicate returns true.
+	// PopUntil removes routes until the predicate returns true for the top route.
+	// Each route's WillPop is checked before removal; removal stops if WillPop
+	// returns false. Routes are removed without animation.
 	PopUntil(predicate func(Route) bool)
 
-	// PushReplacement replaces the current route.
+	// PushReplacement replaces the current route with a new route.
+	// If a Redirect callback is configured and the route has a name,
+	// the redirect logic is applied before replacing.
 	PushReplacement(route Route)
 
-	// CanPop returns true if there's a route to pop.
+	// CanPop returns true if there are routes that can be popped.
+	// Returns false if only the root route remains.
 	CanPop() bool
 
-	// MaybePop pops if possible, returns true if popped.
+	// MaybePop attempts to pop if possible.
+	// Checks CanPop and the top route's WillPop before popping.
+	// Returns true if a route was popped, false otherwise.
 	MaybePop(result any) bool
 }
 
 type navigatorState struct {
-	element      *core.StatefulElement
-	navigator    Navigator
-	routes       []Route
-	exitingRoute Route // route currently animating out
+	element            *core.StatefulElement
+	navigator          Navigator
+	routes             []Route
+	exitingRoute       Route  // route currently animating out
+	isRefreshing       bool   // guard against re-entrant refresh
+	unsubscribeRefresh func() // cleanup for RefreshListenable
 }
 
 func (s *navigatorState) setElement(element *core.StatefulElement) {
@@ -111,14 +280,29 @@ func (s *navigatorState) SetElement(element *core.StatefulElement) {
 func (s *navigatorState) InitState() {
 	s.navigator = s.element.Widget().(Navigator)
 
-	// Register as the global navigator for back button handling
-	globalNavigatorMu.Lock()
-	globalNavigator = s
-	globalNavigatorMu.Unlock()
+	// Register as root navigator if IsRoot is set
+	if s.navigator.IsRoot {
+		globalScope.SetRoot(s)
+	}
 
-	// Push the initial route
+	// Set up RefreshListenable for auth state changes
+	if s.navigator.RefreshListenable != nil {
+		s.unsubscribeRefresh = s.navigator.RefreshListenable.AddListener(s.onRefresh)
+	}
+
+	// Push the initial route (with redirect support)
 	if s.navigator.InitialRoute != "" && s.navigator.OnGenerateRoute != nil {
-		settings := RouteSettings{Name: s.navigator.InitialRoute}
+		initialPath := s.navigator.InitialRoute
+		var initialArgs any
+
+		// Apply redirect to initial route
+		if s.navigator.Redirect != nil {
+			finalPath, finalArgs, _, _ := s.applyRedirect("", initialPath, initialArgs)
+			initialPath = finalPath
+			initialArgs = finalArgs
+		}
+
+		settings := RouteSettings{Name: initialPath, Arguments: initialArgs}
 		route := s.navigator.OnGenerateRoute(settings)
 		if route == nil && s.navigator.OnUnknownRoute != nil {
 			route = s.navigator.OnUnknownRoute(settings)
@@ -135,6 +319,9 @@ func (s *navigatorState) InitState() {
 }
 
 func (s *navigatorState) Build(ctx core.BuildContext) core.Widget {
+	// Register with TabScaffold if we're inside one (for active navigator tracking)
+	tryRegisterTabNavigator(ctx, s)
+
 	// Build all routes in a Stack
 	children := make([]core.Widget, 0, len(s.routes)+1)
 	for i, route := range s.routes {
@@ -183,12 +370,17 @@ func (s *navigatorState) SetState(fn func()) {
 }
 
 func (s *navigatorState) Dispose() {
-	// Unregister from global navigator if this is the active one
-	globalNavigatorMu.Lock()
-	if globalNavigator == s {
-		globalNavigator = nil
+	// Unsubscribe from RefreshListenable
+	if s.unsubscribeRefresh != nil {
+		s.unsubscribeRefresh()
+		s.unsubscribeRefresh = nil
 	}
-	globalNavigatorMu.Unlock()
+
+	// Clear from NavigationScope
+	globalScope.ClearActiveIf(s)
+	if s.navigator.IsRoot {
+		globalScope.ClearRootIf(s)
+	}
 }
 
 func (s *navigatorState) DidChangeDependencies() {}
@@ -198,21 +390,61 @@ func (s *navigatorState) DidUpdateWidget(oldWidget core.StatefulWidget) {
 }
 
 // Push adds a route to the stack.
+// If the route has a name and a Redirect callback is configured, the redirect
+// will be applied. Routes with empty Settings().Name skip redirect checks.
 func (s *navigatorState) Push(route Route) {
+	fromPath := ""
+	if len(s.routes) > 0 {
+		fromPath = s.routes[len(s.routes)-1].Settings().Name
+	}
+
+	toPath := route.Settings().Name
+	toArgs := route.Settings().Arguments
+
+	// Guard: only apply redirect if route has a name
+	// Push(route) with empty name is unguarded
+	if toPath != "" && s.navigator.Redirect != nil {
+		finalPath, finalArgs, replace, _ := s.applyRedirect(fromPath, toPath, toArgs)
+
+		if finalPath != toPath {
+			// Redirect occurred - generate new route
+			newSettings := RouteSettings{Name: finalPath, Arguments: finalArgs}
+			route = s.navigator.OnGenerateRoute(newSettings)
+			if route == nil && s.navigator.OnUnknownRoute != nil {
+				route = s.navigator.OnUnknownRoute(newSettings)
+			}
+			if route == nil {
+				return
+			}
+		}
+
+		if replace && len(s.routes) > 0 {
+			s.doPushReplacement(route)
+			return
+		}
+	}
+
+	s.doPush(route)
+}
+
+// doPush performs the actual push without redirect checks.
+func (s *navigatorState) doPush(route Route) {
 	s.SetState(func() {
-		// Notify current top route
+		var previousTop Route
 		if len(s.routes) > 0 {
-			s.routes[len(s.routes)-1].DidChangeNext(route)
+			previousTop = s.routes[len(s.routes)-1]
+			previousTop.DidChangeNext(route)
 		}
 		s.routes = append(s.routes, route)
+
+		// Notify new route of its previous
+		route.DidChangePrevious(previousTop)
+
 		route.DidPush()
+
 		// Notify observers
-		var previousRoute Route
-		if len(s.routes) > 1 {
-			previousRoute = s.routes[len(s.routes)-2]
-		}
 		for _, observer := range s.navigator.Observers {
-			observer.DidPush(route, previousRoute)
+			observer.DidPush(route, previousTop)
 		}
 	})
 }
@@ -229,19 +461,52 @@ func (s *navigatorState) routeFromName(name string, args any) Route {
 	return route
 }
 
-// PushNamed pushes a route by name.
+// PushNamed pushes a route by name, applying redirect if configured.
 func (s *navigatorState) PushNamed(name string, args any) {
-	route := s.routeFromName(name, args)
-	if route != nil {
-		s.Push(route)
+	fromPath := ""
+	if len(s.routes) > 0 {
+		fromPath = s.routes[len(s.routes)-1].Settings().Name
+	}
+
+	finalPath := name
+	finalArgs := args
+	replace := false
+
+	// Apply redirect
+	if s.navigator.Redirect != nil {
+		finalPath, finalArgs, replace, _ = s.applyRedirect(fromPath, name, args)
+	}
+
+	route := s.routeFromName(finalPath, finalArgs)
+	if route == nil {
+		return
+	}
+
+	if replace && len(s.routes) > 0 {
+		s.doPushReplacement(route)
+	} else {
+		s.doPush(route)
 	}
 }
 
-// PushReplacementNamed replaces the current route.
+// PushReplacementNamed replaces the current route, applying redirect if configured.
 func (s *navigatorState) PushReplacementNamed(name string, args any) {
-	route := s.routeFromName(name, args)
+	fromPath := ""
+	if len(s.routes) > 0 {
+		fromPath = s.routes[len(s.routes)-1].Settings().Name
+	}
+
+	finalPath := name
+	finalArgs := args
+
+	// Apply redirect
+	if s.navigator.Redirect != nil {
+		finalPath, finalArgs, _, _ = s.applyRedirect(fromPath, name, args)
+	}
+
+	route := s.routeFromName(finalPath, finalArgs)
 	if route != nil {
-		s.PushReplacement(route)
+		s.doPushReplacement(route)
 	}
 }
 
@@ -296,6 +561,9 @@ func (s *navigatorState) Pop(result any) {
 }
 
 // PopUntil removes routes until the predicate returns true.
+// Routes are removed immediately without animation. Each route's WillPop is
+// checked before removal - if WillPop returns false, the removal stops.
+// Observer DidRemove callbacks are fired for each removed route.
 func (s *navigatorState) PopUntil(predicate func(Route) bool) {
 	s.SetState(func() {
 		for len(s.routes) > 1 {
@@ -303,8 +571,18 @@ func (s *navigatorState) PopUntil(predicate func(Route) bool) {
 			if predicate(top) {
 				break
 			}
+			// Check WillPop before removing
+			if !top.WillPop() {
+				break
+			}
 			s.routes = s.routes[:len(s.routes)-1]
-			top.DidPop(nil)
+
+			// Fire lifecycle and observers
+			var previous Route
+			if len(s.routes) > 0 {
+				previous = s.routes[len(s.routes)-1]
+			}
+			s.removeRoute(top, previous)
 		}
 		// Notify new top
 		if len(s.routes) > 0 {
@@ -313,17 +591,70 @@ func (s *navigatorState) PopUntil(predicate func(Route) bool) {
 	})
 }
 
+// removeRoute fires DidPop and observer callbacks for a removed route.
+func (s *navigatorState) removeRoute(route Route, previousRoute Route) {
+	route.DidPop(nil)
+	for _, observer := range s.navigator.Observers {
+		observer.DidRemove(route, previousRoute)
+	}
+}
+
 // PushReplacement replaces the current route.
+// If the route has a name and a Redirect callback is configured, the redirect
+// will be applied.
 func (s *navigatorState) PushReplacement(route Route) {
 	if len(s.routes) == 0 {
 		s.Push(route)
 		return
 	}
+
+	fromPath := s.routes[len(s.routes)-1].Settings().Name
+	toPath := route.Settings().Name
+	toArgs := route.Settings().Arguments
+
+	// Apply redirect if route has a name
+	if toPath != "" && s.navigator.Redirect != nil {
+		finalPath, finalArgs, _, _ := s.applyRedirect(fromPath, toPath, toArgs)
+
+		if finalPath != toPath {
+			// Redirect occurred - generate new route
+			newSettings := RouteSettings{Name: finalPath, Arguments: finalArgs}
+			route = s.navigator.OnGenerateRoute(newSettings)
+			if route == nil && s.navigator.OnUnknownRoute != nil {
+				route = s.navigator.OnUnknownRoute(newSettings)
+			}
+			if route == nil {
+				return
+			}
+		}
+	}
+
+	s.doPushReplacement(route)
+}
+
+// doPushReplacement performs the actual replacement without redirect checks.
+func (s *navigatorState) doPushReplacement(route Route) {
+	if len(s.routes) == 0 {
+		s.doPush(route)
+		return
+	}
 	s.SetState(func() {
 		oldRoute := s.routes[len(s.routes)-1]
+
+		// Get previous of old route (for new route's DidChangePrevious)
+		var previousOfOld Route
+		if len(s.routes) > 1 {
+			previousOfOld = s.routes[len(s.routes)-2]
+		}
+
 		s.routes[len(s.routes)-1] = route
 		oldRoute.DidPop(nil)
+
+		// Notify new route of previous
+		route.DidChangePrevious(previousOfOld)
+
 		route.DidPush()
+
 		// Notify observers
 		for _, observer := range s.navigator.Observers {
 			observer.DidReplace(route, oldRoute)
@@ -411,4 +742,162 @@ func NavigatorOf(ctx core.BuildContext) NavigatorState {
 		return nav.state
 	}
 	return nil
+}
+
+// RedirectContext provides information about the navigation being attempted,
+// allowing the Redirect callback to make informed decisions.
+type RedirectContext struct {
+	// FromPath is the current route's path before navigation.
+	// Empty string on initial route or when navigating from outside a route.
+	FromPath string
+
+	// ToPath is the intended destination path.
+	ToPath string
+
+	// Arguments are the navigation arguments being passed.
+	Arguments any
+}
+
+// RedirectResult tells the navigator how to handle the navigation.
+//
+// Create using helper functions:
+//   - [NoRedirect] to allow navigation to proceed
+//   - [RedirectTo] to redirect to a different path
+//   - [RedirectWithArgs] to redirect with custom arguments
+type RedirectResult struct {
+	// Path is the redirect destination. Empty string means no redirect.
+	Path string
+
+	// Arguments for the redirect destination.
+	// If nil, original arguments are discarded.
+	Arguments any
+
+	// Replace controls whether to replace the current route (true) or push (false).
+	// RedirectTo and RedirectWithArgs set this to true by default.
+	Replace bool
+}
+
+// NoRedirect returns a result that allows navigation to proceed normally.
+// Use this in your Redirect callback when the route should be accessible.
+//
+//	Redirect: func(ctx navigation.RedirectContext) navigation.RedirectResult {
+//	    if isPublicRoute(ctx.ToPath) {
+//	        return navigation.NoRedirect()
+//	    }
+//	    // ... check auth
+//	}
+func NoRedirect() RedirectResult {
+	return RedirectResult{}
+}
+
+// RedirectTo creates a redirect to a different path.
+// The current route is replaced (not pushed) by default.
+//
+//	Redirect: func(ctx navigation.RedirectContext) navigation.RedirectResult {
+//	    if !isLoggedIn {
+//	        return navigation.RedirectTo("/login")
+//	    }
+//	    return navigation.NoRedirect()
+//	}
+func RedirectTo(path string) RedirectResult {
+	return RedirectResult{Path: path, Replace: true}
+}
+
+// RedirectWithArgs creates a redirect with custom arguments.
+// Useful for preserving the intended destination through a login flow.
+//
+//	Redirect: func(ctx navigation.RedirectContext) navigation.RedirectResult {
+//	    if !isLoggedIn && isProtected(ctx.ToPath) {
+//	        return navigation.RedirectWithArgs("/login", map[string]any{
+//	            "returnTo": ctx.ToPath,
+//	        })
+//	    }
+//	    return navigation.NoRedirect()
+//	}
+func RedirectWithArgs(path string, args any) RedirectResult {
+	return RedirectResult{Path: path, Arguments: args, Replace: true}
+}
+
+const (
+	maxRedirects      = 10
+	redirectErrorPath = "/_redirect_error"
+)
+
+// applyRedirect checks and applies redirect for navigation.
+// Returns the final path, args, whether a replace occurred, and any error.
+func (s *navigatorState) applyRedirect(fromPath, toPath string, args any) (string, any, bool, error) {
+	if s.navigator.Redirect == nil {
+		return toPath, args, false, nil
+	}
+
+	seen := make(map[string]bool)
+	currentPath := toPath
+	currentArgs := args
+	replace := false
+
+	for i := 0; i < maxRedirects; i++ {
+		if seen[currentPath] {
+			// Loop detected - return error path for OnUnknownRoute
+			return redirectErrorPath, map[string]any{
+				"error": "redirect_loop",
+				"path":  currentPath,
+			}, true, nil
+		}
+		seen[currentPath] = true
+
+		ctx := RedirectContext{
+			FromPath:  fromPath,
+			ToPath:    currentPath,
+			Arguments: currentArgs,
+		}
+		result := s.navigator.Redirect(ctx)
+
+		if result.Path == "" || result.Path == currentPath {
+			return currentPath, currentArgs, replace, nil
+		}
+
+		currentPath = result.Path
+		currentArgs = result.Arguments
+		replace = replace || result.Replace
+	}
+
+	// Max redirects exceeded - return error path
+	return redirectErrorPath, map[string]any{
+		"error": "max_redirects",
+		"limit": maxRedirects,
+	}, true, nil
+}
+
+// onRefresh handles RefreshListenable notifications to re-evaluate redirects.
+func (s *navigatorState) onRefresh() {
+	// Guard against re-entrancy
+	if s.isRefreshing {
+		return
+	}
+
+	// Guard: only process refresh if this is the active navigator
+	// Prevents duplicate redirects across nested navigators
+	if globalScope.ActiveNavigator() != NavigatorState(s) {
+		return
+	}
+
+	// Guard: need routes and redirect callback
+	if len(s.routes) == 0 || s.navigator.Redirect == nil {
+		return
+	}
+
+	s.isRefreshing = true
+	defer func() { s.isRefreshing = false }()
+
+	current := s.routes[len(s.routes)-1]
+	ctx := RedirectContext{
+		FromPath:  current.Settings().Name,
+		ToPath:    current.Settings().Name,
+		Arguments: current.Settings().Arguments,
+	}
+	result := s.navigator.Redirect(ctx)
+
+	if result.Path != "" && result.Path != current.Settings().Name {
+		s.PushReplacementNamed(result.Path, result.Arguments)
+	}
 }

--- a/pkg/navigation/navigator_test.go
+++ b/pkg/navigation/navigator_test.go
@@ -1,0 +1,319 @@
+package navigation
+
+import (
+	"testing"
+
+	"github.com/go-drift/drift/pkg/core"
+)
+
+// mockNavigatorState implements NavigatorState for testing
+type mockNavigatorState struct {
+	canPopResult bool
+	popCalled    bool
+	popResult    any
+}
+
+func (m *mockNavigatorState) Push(route Route)                           {}
+func (m *mockNavigatorState) PushNamed(name string, args any)            {}
+func (m *mockNavigatorState) PushReplacementNamed(name string, args any) {}
+func (m *mockNavigatorState) Pop(result any)                             { m.popCalled = true; m.popResult = result }
+func (m *mockNavigatorState) PopUntil(predicate func(Route) bool)        {}
+func (m *mockNavigatorState) PushReplacement(route Route)                {}
+func (m *mockNavigatorState) CanPop() bool                               { return m.canPopResult }
+func (m *mockNavigatorState) MaybePop(result any) bool {
+	if m.canPopResult {
+		m.popCalled = true
+		m.popResult = result
+		return true
+	}
+	return false
+}
+
+func TestNavigationScope_SetRoot(t *testing.T) {
+	scope := &NavigationScope{}
+	nav := &mockNavigatorState{}
+
+	scope.SetRoot(nav)
+
+	if scope.root != nav {
+		t.Error("SetRoot should set root navigator")
+	}
+	if scope.activeNavigator != nav {
+		t.Error("SetRoot should set activeNavigator when nil")
+	}
+}
+
+func TestNavigationScope_SetRoot_PreservesActive(t *testing.T) {
+	scope := &NavigationScope{}
+	nav1 := &mockNavigatorState{}
+	nav2 := &mockNavigatorState{}
+
+	scope.SetActiveNavigator(nav1)
+	scope.SetRoot(nav2)
+
+	if scope.root != nav2 {
+		t.Error("SetRoot should set root navigator")
+	}
+	if scope.activeNavigator != nav1 {
+		t.Error("SetRoot should preserve existing activeNavigator")
+	}
+}
+
+func TestNavigationScope_SetActiveNavigator(t *testing.T) {
+	scope := &NavigationScope{}
+	nav := &mockNavigatorState{}
+
+	scope.SetActiveNavigator(nav)
+
+	if scope.activeNavigator != nav {
+		t.Error("SetActiveNavigator should set active navigator")
+	}
+}
+
+func TestNavigationScope_ActiveNavigator(t *testing.T) {
+	scope := &NavigationScope{}
+	root := &mockNavigatorState{}
+	active := &mockNavigatorState{}
+
+	// When nothing is set, returns nil
+	if scope.ActiveNavigator() != nil {
+		t.Error("ActiveNavigator should return nil when nothing set")
+	}
+
+	// When only root is set, returns root
+	scope.SetRoot(root)
+	if scope.ActiveNavigator() != root {
+		t.Error("ActiveNavigator should return root when no explicit active")
+	}
+
+	// When active is set, returns active
+	scope.SetActiveNavigator(active)
+	if scope.ActiveNavigator() != active {
+		t.Error("ActiveNavigator should return active navigator")
+	}
+}
+
+func TestNavigationScope_ClearActiveIf(t *testing.T) {
+	scope := &NavigationScope{}
+	root := &mockNavigatorState{}
+	active := &mockNavigatorState{}
+	other := &mockNavigatorState{}
+
+	scope.SetRoot(root)
+	scope.SetActiveNavigator(active)
+
+	// Clearing a different navigator does nothing
+	scope.ClearActiveIf(other)
+	if scope.activeNavigator != active {
+		t.Error("ClearActiveIf should not clear when nav doesn't match")
+	}
+
+	// Clearing the active navigator falls back to root
+	scope.ClearActiveIf(active)
+	if scope.activeNavigator != root {
+		t.Error("ClearActiveIf should fall back to root")
+	}
+}
+
+func TestNavigationScope_ClearRootIf(t *testing.T) {
+	scope := &NavigationScope{}
+	root := &mockNavigatorState{}
+	other := &mockNavigatorState{}
+
+	scope.SetRoot(root)
+
+	// Clearing a different navigator does nothing
+	scope.ClearRootIf(other)
+	if scope.root != root {
+		t.Error("ClearRootIf should not clear when nav doesn't match")
+	}
+
+	// Clearing the root navigator
+	scope.ClearRootIf(root)
+	if scope.root != nil {
+		t.Error("ClearRootIf should clear root")
+	}
+}
+
+func TestHandleBackButton_NoNavigator(t *testing.T) {
+	// Save and restore global state
+	oldScope := globalScope
+	globalScope = &NavigationScope{}
+	defer func() { globalScope = oldScope }()
+
+	if HandleBackButton() {
+		t.Error("HandleBackButton should return false when no navigator")
+	}
+}
+
+func TestHandleBackButton_ActiveCanPop(t *testing.T) {
+	oldScope := globalScope
+	globalScope = &NavigationScope{}
+	defer func() { globalScope = oldScope }()
+
+	active := &mockNavigatorState{canPopResult: true}
+	globalScope.SetActiveNavigator(active)
+
+	if !HandleBackButton() {
+		t.Error("HandleBackButton should return true when active can pop")
+	}
+	if !active.popCalled {
+		t.Error("HandleBackButton should call MaybePop on active")
+	}
+}
+
+func TestHandleBackButton_FallbackToRoot(t *testing.T) {
+	oldScope := globalScope
+	globalScope = &NavigationScope{}
+	defer func() { globalScope = oldScope }()
+
+	root := &mockNavigatorState{canPopResult: true}
+	active := &mockNavigatorState{canPopResult: false}
+	globalScope.SetRoot(root)
+	globalScope.SetActiveNavigator(active)
+
+	if !HandleBackButton() {
+		t.Error("HandleBackButton should return true when root can pop")
+	}
+	if !root.popCalled {
+		t.Error("HandleBackButton should fall back to root")
+	}
+}
+
+func TestHandleBackButton_NoFallbackWhenSame(t *testing.T) {
+	oldScope := globalScope
+	globalScope = &NavigationScope{}
+	defer func() { globalScope = oldScope }()
+
+	// When active == root, don't try to pop root again
+	nav := &mockNavigatorState{canPopResult: false}
+	globalScope.SetRoot(nav)
+	// active will be set to nav by SetRoot since activeNavigator was nil
+
+	if HandleBackButton() {
+		t.Error("HandleBackButton should return false when at root")
+	}
+}
+
+func TestRootNavigator(t *testing.T) {
+	oldScope := globalScope
+	globalScope = &NavigationScope{}
+	defer func() { globalScope = oldScope }()
+
+	// Initially nil
+	if RootNavigator() != nil {
+		t.Error("RootNavigator should be nil when no root set")
+	}
+
+	root := &mockNavigatorState{}
+	globalScope.SetRoot(root)
+
+	if RootNavigator() != root {
+		t.Error("RootNavigator should return the root navigator")
+	}
+}
+
+func TestRootNavigator_IndependentOfActive(t *testing.T) {
+	oldScope := globalScope
+	globalScope = &NavigationScope{}
+	defer func() { globalScope = oldScope }()
+
+	root := &mockNavigatorState{}
+	active := &mockNavigatorState{}
+
+	globalScope.SetRoot(root)
+	globalScope.SetActiveNavigator(active)
+
+	// RootNavigator always returns root, regardless of active
+	if RootNavigator() != root {
+		t.Error("RootNavigator should return root navigator, not active")
+	}
+}
+
+func TestRedirectResult_Helpers(t *testing.T) {
+	// NoRedirect
+	r := NoRedirect()
+	if r.Path != "" {
+		t.Error("NoRedirect should have empty path")
+	}
+
+	// RedirectTo
+	r = RedirectTo("/login")
+	if r.Path != "/login" {
+		t.Errorf("RedirectTo path = %q, want /login", r.Path)
+	}
+	if !r.Replace {
+		t.Error("RedirectTo should set Replace=true")
+	}
+
+	// RedirectWithArgs
+	r = RedirectWithArgs("/login", map[string]any{"returnTo": "/dashboard"})
+	if r.Path != "/login" {
+		t.Errorf("RedirectWithArgs path = %q, want /login", r.Path)
+	}
+	if r.Arguments == nil {
+		t.Error("RedirectWithArgs should set arguments")
+	}
+	if !r.Replace {
+		t.Error("RedirectWithArgs should set Replace=true")
+	}
+}
+
+// mockRoute implements Route for testing
+type mockRoute struct {
+	settings            RouteSettings
+	didPushCalled       bool
+	didPopCalled        bool
+	didPopResult        any
+	didChangeNextCalled bool
+	didChangeNextRoute  Route
+	didChangePrevCalled bool
+	didChangePrevRoute  Route
+	willPopResult       bool
+}
+
+func newMockRoute(name string) *mockRoute {
+	return &mockRoute{
+		settings:      RouteSettings{Name: name},
+		willPopResult: true,
+	}
+}
+
+func (m *mockRoute) Build(ctx core.BuildContext) core.Widget { return nil }
+func (m *mockRoute) Settings() RouteSettings                 { return m.settings }
+func (m *mockRoute) DidPush()                                { m.didPushCalled = true }
+func (m *mockRoute) DidPop(result any) {
+	m.didPopCalled = true
+	m.didPopResult = result
+}
+func (m *mockRoute) DidChangeNext(nextRoute Route) {
+	m.didChangeNextCalled = true
+	m.didChangeNextRoute = nextRoute
+}
+func (m *mockRoute) DidChangePrevious(previousRoute Route) {
+	m.didChangePrevCalled = true
+	m.didChangePrevRoute = previousRoute
+}
+func (m *mockRoute) WillPop() bool { return m.willPopResult }
+
+func TestBaseRoute_Defaults(t *testing.T) {
+	r := NewBaseRoute(RouteSettings{Name: "/test", Arguments: "args"})
+
+	if r.Settings().Name != "/test" {
+		t.Errorf("Settings().Name = %q, want /test", r.Settings().Name)
+	}
+	if r.Settings().Arguments != "args" {
+		t.Errorf("Settings().Arguments = %v, want args", r.Settings().Arguments)
+	}
+
+	// Default WillPop returns true
+	if !r.WillPop() {
+		t.Error("BaseRoute.WillPop() should return true by default")
+	}
+
+	// Lifecycle methods are no-ops (shouldn't panic)
+	r.DidPush()
+	r.DidPop(nil)
+	r.DidChangeNext(nil)
+	r.DidChangePrevious(nil)
+}

--- a/pkg/navigation/path_matcher.go
+++ b/pkg/navigation/path_matcher.go
@@ -1,0 +1,351 @@
+package navigation
+
+import (
+	"net/url"
+	"strings"
+)
+
+// TrailingSlashBehavior controls how trailing slashes are handled during
+// path matching.
+type TrailingSlashBehavior int
+
+const (
+	// TrailingSlashStrip removes trailing slashes before matching.
+	// This is the default behavior, making "/products/1/" match "/products/:id".
+	TrailingSlashStrip TrailingSlashBehavior = iota
+
+	// TrailingSlashStrict requires exact trailing slash match.
+	// With this setting, "/products/1/" does NOT match "/products/:id".
+	TrailingSlashStrict
+)
+
+// CaseSensitivity controls whether path matching is case-sensitive.
+type CaseSensitivity int
+
+const (
+	// CaseSensitive requires exact case match in path segments.
+	// This is the default behavior: "/Products" does NOT match "/products".
+	CaseSensitive CaseSensitivity = iota
+
+	// CaseInsensitive ignores case when matching path segments.
+	// With this setting, "/Products" matches "/products".
+	CaseInsensitive
+)
+
+// PathPattern represents a compiled URL pattern for route matching.
+//
+// Patterns support three types of segments:
+//   - Static: "/products", "/users/list" - must match exactly
+//   - Parameter: ":id", ":name" - captures a single path segment
+//   - Wildcard: "*path" - captures all remaining segments (must be last)
+//
+// Create patterns using [NewPathPattern]:
+//
+//	pattern := navigation.NewPathPattern("/products/:id")
+//	params, ok := pattern.Match("/products/123")
+//	// params = {"id": "123"}, ok = true
+type PathPattern struct {
+	pattern               string
+	segments              []segment
+	trailingSlash         TrailingSlashBehavior
+	caseSensitivity       CaseSensitivity
+	hasWildcard           bool
+	wildcardParamName     string
+	requiresTrailingSlash bool // true if pattern ends with / in strict mode
+}
+
+type segment struct {
+	value   string
+	isParam bool
+	isWild  bool // * catches rest of path
+}
+
+// PathPatternOption configures a [PathPattern] during creation.
+type PathPatternOption func(*PathPattern)
+
+// WithTrailingSlash sets how trailing slashes are handled during matching.
+//
+//	// Strict mode - trailing slash must match exactly
+//	pattern := navigation.NewPathPattern("/products/:id",
+//	    navigation.WithTrailingSlash(navigation.TrailingSlashStrict),
+//	)
+func WithTrailingSlash(behavior TrailingSlashBehavior) PathPatternOption {
+	return func(p *PathPattern) {
+		p.trailingSlash = behavior
+	}
+}
+
+// WithCaseSensitivity sets whether matching is case-sensitive.
+//
+//	// Case-insensitive matching
+//	pattern := navigation.NewPathPattern("/Products/:id",
+//	    navigation.WithCaseSensitivity(navigation.CaseInsensitive),
+//	)
+func WithCaseSensitivity(sensitivity CaseSensitivity) PathPatternOption {
+	return func(p *PathPattern) {
+		p.caseSensitivity = sensitivity
+	}
+}
+
+// NewPathPattern compiles a pattern string into a PathPattern.
+// Pattern syntax:
+//   - Static segments: /products, /users
+//   - Parameters: :id, :name (captures a single segment)
+//   - Wildcards: *path (captures remaining path, must be last)
+//
+// Examples:
+//   - "/products/:id" matches "/products/123" -> {"id": "123"}
+//   - "/files/*path" matches "/files/a/b/c" -> {"path": "a/b/c"}
+func NewPathPattern(pattern string, opts ...PathPatternOption) *PathPattern {
+	p := &PathPattern{
+		pattern:         pattern,
+		trailingSlash:   TrailingSlashStrip,
+		caseSensitivity: CaseSensitive,
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	// Track if pattern requires trailing slash (only meaningful in strict mode)
+	hasTrailingSlash := strings.HasSuffix(pattern, "/") && pattern != "/"
+	if p.trailingSlash == TrailingSlashStrict && hasTrailingSlash {
+		p.requiresTrailingSlash = true
+	}
+
+	// Normalize pattern for parsing (but we've already captured trailing slash requirement)
+	pattern = strings.TrimSuffix(pattern, "/")
+	if pattern == "" {
+		pattern = "/"
+	}
+
+	// Parse segments
+	if pattern == "/" {
+		p.segments = nil
+		return p
+	}
+
+	parts := strings.Split(strings.TrimPrefix(pattern, "/"), "/")
+	p.segments = make([]segment, 0, len(parts))
+
+	for i, part := range parts {
+		if strings.HasPrefix(part, "*") {
+			// Wildcard - captures rest of path
+			p.hasWildcard = true
+			p.wildcardParamName = strings.TrimPrefix(part, "*")
+			if p.wildcardParamName == "" {
+				p.wildcardParamName = "wildcard"
+			}
+			p.segments = append(p.segments, segment{
+				value:  p.wildcardParamName,
+				isWild: true,
+			})
+			// Wildcard must be last
+			if i < len(parts)-1 {
+				// Invalid pattern, but we'll just ignore trailing parts
+				break
+			}
+		} else if strings.HasPrefix(part, ":") {
+			// Parameter
+			p.segments = append(p.segments, segment{
+				value:   strings.TrimPrefix(part, ":"),
+				isParam: true,
+			})
+		} else {
+			// Static segment
+			p.segments = append(p.segments, segment{
+				value: part,
+			})
+		}
+	}
+
+	return p
+}
+
+// Match checks if a path matches this pattern and extracts parameters.
+//
+// Returns the extracted parameters and true if the path matches, or nil and
+// false if it doesn't match. Percent-encoded values (like %20 for space) are
+// automatically decoded in the returned parameters.
+//
+// Examples:
+//
+//	pattern := navigation.NewPathPattern("/products/:id")
+//
+//	params, ok := pattern.Match("/products/123")
+//	// params = {"id": "123"}, ok = true
+//
+//	params, ok := pattern.Match("/products/hello%20world")
+//	// params = {"id": "hello world"}, ok = true
+//
+//	params, ok := pattern.Match("/users/123")
+//	// params = nil, ok = false
+func (p *PathPattern) Match(path string) (params map[string]string, ok bool) {
+	// Strip query string and fragment if present
+	if idx := strings.IndexAny(path, "?#"); idx >= 0 {
+		path = path[:idx]
+	}
+
+	// Check trailing slash requirement in strict mode
+	pathHasTrailingSlash := strings.HasSuffix(path, "/") && path != "/"
+	if p.trailingSlash == TrailingSlashStrict {
+		if p.requiresTrailingSlash != pathHasTrailingSlash {
+			return nil, false
+		}
+	}
+
+	// Handle trailing slash for matching
+	if p.trailingSlash == TrailingSlashStrip || pathHasTrailingSlash {
+		path = strings.TrimSuffix(path, "/")
+		if path == "" {
+			path = "/"
+		}
+	}
+
+	// Handle case sensitivity
+	matchPath := path
+	if p.caseSensitivity == CaseInsensitive {
+		matchPath = strings.ToLower(path)
+	}
+
+	// Root path special case
+	if len(p.segments) == 0 {
+		if matchPath == "/" {
+			return map[string]string{}, true
+		}
+		return nil, false
+	}
+
+	// Split path into segments
+	pathParts := strings.Split(strings.TrimPrefix(matchPath, "/"), "/")
+	originalParts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+
+	params = make(map[string]string)
+
+	segIdx := 0
+	for i := 0; i < len(pathParts); i++ {
+		if segIdx >= len(p.segments) {
+			// More path segments than pattern segments
+			return nil, false
+		}
+
+		seg := p.segments[segIdx]
+
+		if seg.isWild {
+			// Wildcard captures remaining path
+			remaining := strings.Join(originalParts[i:], "/")
+			decoded, err := url.PathUnescape(remaining)
+			if err != nil {
+				decoded = remaining
+			}
+			params[seg.value] = decoded
+			return params, true
+		}
+
+		if seg.isParam {
+			// Parameter captures this segment
+			decoded, err := url.PathUnescape(originalParts[i])
+			if err != nil {
+				decoded = originalParts[i]
+			}
+			params[seg.value] = decoded
+			segIdx++
+			continue
+		}
+
+		// Static segment must match exactly
+		segValue := seg.value
+		if p.caseSensitivity == CaseInsensitive {
+			segValue = strings.ToLower(segValue)
+		}
+		if pathParts[i] != segValue {
+			return nil, false
+		}
+		segIdx++
+	}
+
+	// Check if we consumed all pattern segments
+	if segIdx < len(p.segments) {
+		// Didn't match all segments - unless the remaining is a wildcard
+		if p.segments[segIdx].isWild {
+			params[p.segments[segIdx].value] = ""
+			return params, true
+		}
+		return nil, false
+	}
+
+	return params, true
+}
+
+// Pattern returns the original pattern string used to create this PathPattern.
+func (p *PathPattern) Pattern() string {
+	return p.pattern
+}
+
+// ParsePath splits a URL into its path and query components.
+//
+// The path is normalized (trailing slash removed) and query parameters are
+// parsed and percent-decoded. URL fragments (#...) are ignored since they
+// are not sent to the server in HTTP requests.
+//
+// Example:
+//
+//	path, query := navigation.ParsePath("/search?q=hello%20world&page=2#results")
+//	// path = "/search"
+//	// query = {"q": ["hello world"], "page": ["2"]}
+func ParsePath(fullPath string) (path string, query map[string][]string) {
+	u, err := url.Parse(fullPath)
+	if err != nil {
+		return fullPath, nil
+	}
+
+	// Normalize: remove trailing slash
+	path = strings.TrimSuffix(u.Path, "/")
+	if path == "" {
+		path = "/"
+	}
+
+	// Parse query with proper decoding
+	// Fragment (u.Fragment) is intentionally ignored
+	query = u.Query()
+	return path, query
+}
+
+// MatchPath is a convenience function that combines path parsing and
+// [PathPattern.Match] to extract complete [RouteSettings] from a URL.
+//
+// Unlike [ParsePath], this function preserves trailing slashes for matching,
+// allowing [TrailingSlashStrict] patterns to work correctly.
+//
+// Returns RouteSettings with Name, Params, and Query populated if the path
+// matches, or empty settings and false if it doesn't match.
+//
+// Example:
+//
+//	pattern := navigation.NewPathPattern("/products/:id")
+//	settings, ok := navigation.MatchPath(pattern, "/products/123?color=red")
+//	// settings.Name = "/products/123?color=red"
+//	// settings.Params = {"id": "123"}
+//	// settings.Query = {"color": ["red"]}
+//	// ok = true
+func MatchPath(pattern *PathPattern, fullPath string) (settings RouteSettings, ok bool) {
+	// Extract query without normalizing path (preserves trailing slash)
+	_, query := ParsePath(fullPath)
+
+	// Get path portion preserving trailing slash for pattern matching
+	pathOnly := fullPath
+	if idx := strings.IndexAny(fullPath, "?#"); idx >= 0 {
+		pathOnly = fullPath[:idx]
+	}
+
+	params, ok := pattern.Match(pathOnly)
+	if !ok {
+		return RouteSettings{}, false
+	}
+
+	return RouteSettings{
+		Name:   fullPath,
+		Params: params,
+		Query:  query,
+	}, true
+}

--- a/pkg/navigation/path_matcher_test.go
+++ b/pkg/navigation/path_matcher_test.go
@@ -1,0 +1,451 @@
+package navigation
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewPathPattern_Static(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		want    bool
+	}{
+		{"/", "/", true},
+		{"/", "/foo", false},
+		{"/products", "/products", true},
+		{"/products", "/products/", true}, // trailing slash stripped by default
+		{"/products", "/Products", false}, // case sensitive by default
+		{"/products/list", "/products/list", true},
+		{"/products/list", "/products", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"_"+tt.path, func(t *testing.T) {
+			p := NewPathPattern(tt.pattern)
+			_, ok := p.Match(tt.path)
+			if ok != tt.want {
+				t.Errorf("NewPathPattern(%q).Match(%q) = %v, want %v", tt.pattern, tt.path, ok, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewPathPattern_Params(t *testing.T) {
+	tests := []struct {
+		pattern    string
+		path       string
+		wantOK     bool
+		wantParams map[string]string
+	}{
+		{
+			pattern:    "/products/:id",
+			path:       "/products/123",
+			wantOK:     true,
+			wantParams: map[string]string{"id": "123"},
+		},
+		{
+			pattern:    "/products/:id",
+			path:       "/products/",
+			wantOK:     false,
+			wantParams: nil,
+		},
+		{
+			pattern:    "/users/:userId/posts/:postId",
+			path:       "/users/42/posts/99",
+			wantOK:     true,
+			wantParams: map[string]string{"userId": "42", "postId": "99"},
+		},
+		{
+			pattern:    "/products/:id",
+			path:       "/products/hello%20world",
+			wantOK:     true,
+			wantParams: map[string]string{"id": "hello world"}, // percent decoded
+		},
+		{
+			pattern:    "/products/:id",
+			path:       "/users/123",
+			wantOK:     false,
+			wantParams: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"_"+tt.path, func(t *testing.T) {
+			p := NewPathPattern(tt.pattern)
+			params, ok := p.Match(tt.path)
+			if ok != tt.wantOK {
+				t.Errorf("Match() ok = %v, want %v", ok, tt.wantOK)
+			}
+			if tt.wantOK && !reflect.DeepEqual(params, tt.wantParams) {
+				t.Errorf("Match() params = %v, want %v", params, tt.wantParams)
+			}
+		})
+	}
+}
+
+func TestNewPathPattern_Wildcard(t *testing.T) {
+	tests := []struct {
+		pattern    string
+		path       string
+		wantOK     bool
+		wantParams map[string]string
+	}{
+		{
+			pattern:    "/files/*path",
+			path:       "/files/docs/readme.md",
+			wantOK:     true,
+			wantParams: map[string]string{"path": "docs/readme.md"},
+		},
+		{
+			pattern:    "/files/*path",
+			path:       "/files/",
+			wantOK:     true,
+			wantParams: map[string]string{"path": ""},
+		},
+		{
+			pattern:    "/files/*path",
+			path:       "/files",
+			wantOK:     true,
+			wantParams: map[string]string{"path": ""},
+		},
+		{
+			pattern:    "/api/*",
+			path:       "/api/v1/users",
+			wantOK:     true,
+			wantParams: map[string]string{"wildcard": "v1/users"},
+		},
+		{
+			pattern:    "/files/*path",
+			path:       "/other/docs",
+			wantOK:     false,
+			wantParams: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"_"+tt.path, func(t *testing.T) {
+			p := NewPathPattern(tt.pattern)
+			params, ok := p.Match(tt.path)
+			if ok != tt.wantOK {
+				t.Errorf("Match() ok = %v, want %v", ok, tt.wantOK)
+			}
+			if tt.wantOK && !reflect.DeepEqual(params, tt.wantParams) {
+				t.Errorf("Match() params = %v, want %v", params, tt.wantParams)
+			}
+		})
+	}
+}
+
+func TestNewPathPattern_TrailingSlash(t *testing.T) {
+	// Default: strip trailing slash
+	p := NewPathPattern("/products/:id")
+	_, ok := p.Match("/products/123/")
+	if !ok {
+		t.Error("TrailingSlashStrip should match paths with trailing slash")
+	}
+
+	// Strict: require exact match
+	p = NewPathPattern("/products/:id", WithTrailingSlash(TrailingSlashStrict))
+	_, ok = p.Match("/products/123/")
+	if ok {
+		t.Error("TrailingSlashStrict should not match paths with trailing slash")
+	}
+	_, ok = p.Match("/products/123")
+	if !ok {
+		t.Error("TrailingSlashStrict should match paths without trailing slash")
+	}
+}
+
+func TestNewPathPattern_TrailingSlash_RequiresTrailingSlash(t *testing.T) {
+	// Pattern that requires trailing slash
+	p := NewPathPattern("/products/:id/", WithTrailingSlash(TrailingSlashStrict))
+
+	// Should match paths WITH trailing slash
+	_, ok := p.Match("/products/123/")
+	if !ok {
+		t.Error("Pattern /products/:id/ should match /products/123/ with trailing slash")
+	}
+
+	// Should NOT match paths WITHOUT trailing slash
+	_, ok = p.Match("/products/123")
+	if ok {
+		t.Error("Pattern /products/:id/ should NOT match /products/123 without trailing slash")
+	}
+}
+
+func TestNewPathPattern_TrailingSlash_StripMode_IgnoresPatternTrailingSlash(t *testing.T) {
+	// In strip mode, pattern's trailing slash doesn't matter
+	p := NewPathPattern("/products/:id/", WithTrailingSlash(TrailingSlashStrip))
+
+	// Both with and without trailing slash should match
+	_, ok := p.Match("/products/123/")
+	if !ok {
+		t.Error("Strip mode should match with trailing slash")
+	}
+
+	_, ok = p.Match("/products/123")
+	if !ok {
+		t.Error("Strip mode should match without trailing slash")
+	}
+}
+
+func TestNewPathPattern_CaseSensitivity(t *testing.T) {
+	// Default: case sensitive
+	p := NewPathPattern("/Products/:id")
+	_, ok := p.Match("/products/123")
+	if ok {
+		t.Error("CaseSensitive should not match different case")
+	}
+	_, ok = p.Match("/Products/123")
+	if !ok {
+		t.Error("CaseSensitive should match same case")
+	}
+
+	// Case insensitive
+	p = NewPathPattern("/Products/:id", WithCaseSensitivity(CaseInsensitive))
+	_, ok = p.Match("/products/123")
+	if !ok {
+		t.Error("CaseInsensitive should match different case")
+	}
+	_, ok = p.Match("/PRODUCTS/123")
+	if !ok {
+		t.Error("CaseInsensitive should match uppercase")
+	}
+}
+
+func TestNewPathPattern_QueryAndFragment(t *testing.T) {
+	p := NewPathPattern("/products/:id")
+
+	// Query string should be stripped for matching
+	params, ok := p.Match("/products/123?color=red")
+	if !ok {
+		t.Error("Should match path with query string")
+	}
+	if params["id"] != "123" {
+		t.Errorf("Should extract param without query, got %q", params["id"])
+	}
+
+	// Fragment should be stripped for matching
+	params, ok = p.Match("/products/456#section")
+	if !ok {
+		t.Error("Should match path with fragment")
+	}
+	if params["id"] != "456" {
+		t.Errorf("Should extract param without fragment, got %q", params["id"])
+	}
+}
+
+func TestPathPattern_Pattern(t *testing.T) {
+	p := NewPathPattern("/products/:id")
+	if p.Pattern() != "/products/:id" {
+		t.Errorf("Pattern() = %q, want %q", p.Pattern(), "/products/:id")
+	}
+}
+
+func TestParsePath(t *testing.T) {
+	tests := []struct {
+		fullPath  string
+		wantPath  string
+		wantQuery map[string][]string
+	}{
+		{
+			fullPath:  "/search",
+			wantPath:  "/search",
+			wantQuery: map[string][]string{},
+		},
+		{
+			fullPath:  "/search?q=hello",
+			wantPath:  "/search",
+			wantQuery: map[string][]string{"q": {"hello"}},
+		},
+		{
+			fullPath:  "/search?q=hello&page=2",
+			wantPath:  "/search",
+			wantQuery: map[string][]string{"q": {"hello"}, "page": {"2"}},
+		},
+		{
+			fullPath:  "/search?tag=a&tag=b",
+			wantPath:  "/search",
+			wantQuery: map[string][]string{"tag": {"a", "b"}},
+		},
+		{
+			fullPath:  "/search?q=hello%20world",
+			wantPath:  "/search",
+			wantQuery: map[string][]string{"q": {"hello world"}},
+		},
+		{
+			fullPath:  "/search#results",
+			wantPath:  "/search",
+			wantQuery: map[string][]string{},
+		},
+		{
+			fullPath:  "/search?q=test#results",
+			wantPath:  "/search",
+			wantQuery: map[string][]string{"q": {"test"}},
+		},
+		{
+			fullPath:  "/path/",
+			wantPath:  "/path",
+			wantQuery: map[string][]string{},
+		},
+		{
+			fullPath:  "/",
+			wantPath:  "/",
+			wantQuery: map[string][]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.fullPath, func(t *testing.T) {
+			path, query := ParsePath(tt.fullPath)
+			if path != tt.wantPath {
+				t.Errorf("ParsePath(%q) path = %q, want %q", tt.fullPath, path, tt.wantPath)
+			}
+			if !reflect.DeepEqual(query, tt.wantQuery) {
+				t.Errorf("ParsePath(%q) query = %v, want %v", tt.fullPath, query, tt.wantQuery)
+			}
+		})
+	}
+}
+
+func TestMatchPath(t *testing.T) {
+	pattern := NewPathPattern("/products/:id")
+
+	settings, ok := MatchPath(pattern, "/products/123?color=red")
+	if !ok {
+		t.Fatal("MatchPath should match")
+	}
+	if settings.Name != "/products/123?color=red" {
+		t.Errorf("Name = %q, want %q", settings.Name, "/products/123?color=red")
+	}
+	if settings.Params["id"] != "123" {
+		t.Errorf("Params[id] = %q, want %q", settings.Params["id"], "123")
+	}
+	if settings.Query["color"][0] != "red" {
+		t.Errorf("Query[color] = %v, want [red]", settings.Query["color"])
+	}
+}
+
+func TestRouteSettings_Param(t *testing.T) {
+	s := RouteSettings{
+		Params: map[string]string{"id": "123", "name": "test"},
+	}
+
+	if s.Param("id") != "123" {
+		t.Errorf("Param(id) = %q, want %q", s.Param("id"), "123")
+	}
+	if s.Param("name") != "test" {
+		t.Errorf("Param(name) = %q, want %q", s.Param("name"), "test")
+	}
+	if s.Param("missing") != "" {
+		t.Errorf("Param(missing) = %q, want empty string", s.Param("missing"))
+	}
+
+	// Nil params map
+	s2 := RouteSettings{}
+	if s2.Param("id") != "" {
+		t.Errorf("Param on nil map = %q, want empty string", s2.Param("id"))
+	}
+}
+
+func TestRouteSettings_QueryValue(t *testing.T) {
+	s := RouteSettings{
+		Query: map[string][]string{
+			"q":    {"hello"},
+			"tags": {"a", "b", "c"},
+		},
+	}
+
+	if s.QueryValue("q") != "hello" {
+		t.Errorf("QueryValue(q) = %q, want %q", s.QueryValue("q"), "hello")
+	}
+	if s.QueryValue("tags") != "a" {
+		t.Errorf("QueryValue(tags) = %q, want %q", s.QueryValue("tags"), "a")
+	}
+	if s.QueryValue("missing") != "" {
+		t.Errorf("QueryValue(missing) = %q, want empty string", s.QueryValue("missing"))
+	}
+
+	// Nil query map
+	s2 := RouteSettings{}
+	if s2.QueryValue("q") != "" {
+		t.Errorf("QueryValue on nil map = %q, want empty string", s2.QueryValue("q"))
+	}
+}
+
+func TestRouteSettings_QueryValues(t *testing.T) {
+	s := RouteSettings{
+		Query: map[string][]string{
+			"tags": {"a", "b", "c"},
+		},
+	}
+
+	vals := s.QueryValues("tags")
+	if !reflect.DeepEqual(vals, []string{"a", "b", "c"}) {
+		t.Errorf("QueryValues(tags) = %v, want [a b c]", vals)
+	}
+	if s.QueryValues("missing") != nil {
+		t.Errorf("QueryValues(missing) = %v, want nil", s.QueryValues("missing"))
+	}
+
+	// Nil query map
+	s2 := RouteSettings{}
+	if s2.QueryValues("tags") != nil {
+		t.Errorf("QueryValues on nil map = %v, want nil", s2.QueryValues("tags"))
+	}
+}
+
+func TestMatchPath_PreservesTrailingSlash(t *testing.T) {
+	// Pattern requires trailing slash
+	patternWithSlash := NewPathPattern("/products/:id/", WithTrailingSlash(TrailingSlashStrict))
+
+	// Should match path WITH trailing slash
+	settings, ok := MatchPath(patternWithSlash, "/products/123/")
+	if !ok {
+		t.Error("MatchPath should match /products/123/ with trailing slash pattern")
+	}
+	if settings.Params["id"] != "123" {
+		t.Errorf("Params[id] = %q, want 123", settings.Params["id"])
+	}
+
+	// Should NOT match path WITHOUT trailing slash
+	_, ok = MatchPath(patternWithSlash, "/products/123")
+	if ok {
+		t.Error("MatchPath should NOT match /products/123 when pattern requires trailing slash")
+	}
+
+	// Pattern without trailing slash
+	patternWithoutSlash := NewPathPattern("/products/:id", WithTrailingSlash(TrailingSlashStrict))
+
+	// Should match path WITHOUT trailing slash
+	settings, ok = MatchPath(patternWithoutSlash, "/products/456")
+	if !ok {
+		t.Error("MatchPath should match /products/456 without trailing slash")
+	}
+	if settings.Params["id"] != "456" {
+		t.Errorf("Params[id] = %q, want 456", settings.Params["id"])
+	}
+
+	// Should NOT match path WITH trailing slash
+	_, ok = MatchPath(patternWithoutSlash, "/products/456/")
+	if ok {
+		t.Error("MatchPath should NOT match /products/456/ when pattern doesn't have trailing slash")
+	}
+}
+
+func TestMatchPath_WithQueryAndTrailingSlash(t *testing.T) {
+	pattern := NewPathPattern("/products/:id/", WithTrailingSlash(TrailingSlashStrict))
+
+	// Should match with query string
+	settings, ok := MatchPath(pattern, "/products/123/?color=red")
+	if !ok {
+		t.Error("MatchPath should match /products/123/?color=red")
+	}
+	if settings.Params["id"] != "123" {
+		t.Errorf("Params[id] = %q, want 123", settings.Params["id"])
+	}
+	if settings.QueryValue("color") != "red" {
+		t.Errorf("QueryValue(color) = %q, want red", settings.QueryValue("color"))
+	}
+}

--- a/pkg/navigation/route.go
+++ b/pkg/navigation/route.go
@@ -1,14 +1,122 @@
 // Package navigation provides routing and navigation for the Drift framework.
+//
+// The package offers two approaches to navigation:
+//
+// # Imperative Navigation with Navigator
+//
+// Use [Navigator] for imperative, stack-based navigation where you manually
+// define route generation:
+//
+//	navigation.Navigator{
+//	    InitialRoute: "/",
+//	    IsRoot:       true,
+//	    OnGenerateRoute: func(settings navigation.RouteSettings) navigation.Route {
+//	        switch settings.Name {
+//	        case "/":
+//	            return navigation.NewMaterialPageRoute(buildHome, settings)
+//	        case "/details":
+//	            return navigation.NewMaterialPageRoute(buildDetails, settings)
+//	        }
+//	        return nil
+//	    },
+//	}
+//
+// # Declarative Navigation with Router
+//
+// Use [Router] for declarative route configuration with automatic path parameter
+// extraction:
+//
+//	navigation.Router{
+//	    InitialPath: "/",
+//	    Routes: []navigation.RouteConfigurer{
+//	        navigation.RouteConfig{Path: "/", Builder: buildHome},
+//	        navigation.RouteConfig{Path: "/products/:id", Builder: buildProduct},
+//	    },
+//	    ErrorBuilder: build404Page,
+//	}
+//
+// # Accessing Navigation
+//
+// From within the widget tree, use [NavigatorOf] or [RouterOf]:
+//
+//	nav := navigation.NavigatorOf(ctx)
+//	nav.PushNamed("/details", args)
+//
+// From outside the widget tree (deep links, platform callbacks), use [RootNavigator]:
+//
+//	nav := navigation.RootNavigator()
+//	nav.PushNamed("/details", args)
+//
+// # Route Guards
+//
+// Both Navigator and Router support redirect callbacks for authentication
+// and authorization:
+//
+//	Redirect: func(ctx navigation.RedirectContext) navigation.RedirectResult {
+//	    if !isLoggedIn && strings.HasPrefix(ctx.ToPath, "/protected") {
+//	        return navigation.RedirectTo("/login")
+//	    }
+//	    return navigation.NoRedirect()
+//	},
+//
+// # Tab Navigation
+//
+// Use [TabScaffold] for bottom tab navigation with separate navigation stacks
+// per tab. TabScaffold automatically manages which tab's navigator is active
+// for back button handling.
 package navigation
 
 import "github.com/go-drift/drift/pkg/core"
 
-// RouteSettings contains route configuration.
+// RouteSettings contains configuration and parameters for a route.
+//
+// When using the declarative [Router], Params and Query are automatically
+// populated from the URL. When using [Navigator] directly, you can populate
+// these fields manually in OnGenerateRoute.
 type RouteSettings struct {
-	// Name is the route name (e.g., "/home", "/details").
+	// Name is the route path (e.g., "/home", "/products/123").
 	Name string
-	// Arguments contains any arguments passed to the route.
+
+	// Arguments contains arbitrary data passed during navigation.
+	// Use this for complex objects that don't fit in the URL.
 	Arguments any
+
+	// Params contains path parameters extracted from the URL.
+	// For example, "/products/:id" matching "/products/123" yields {"id": "123"}.
+	// Values are automatically percent-decoded.
+	Params map[string]string
+
+	// Query contains query string parameters from the URL.
+	// Supports multiple values per key (e.g., "?tag=a&tag=b").
+	// Values are automatically percent-decoded.
+	Query map[string][]string
+}
+
+// Param returns a path parameter value or empty string if not found.
+func (s RouteSettings) Param(key string) string {
+	if s.Params == nil {
+		return ""
+	}
+	return s.Params[key]
+}
+
+// QueryValue returns the first query parameter value or empty string if not found.
+func (s RouteSettings) QueryValue(key string) string {
+	if s.Query == nil {
+		return ""
+	}
+	if vals, ok := s.Query[key]; ok && len(vals) > 0 {
+		return vals[0]
+	}
+	return ""
+}
+
+// QueryValues returns all query parameter values for a key.
+func (s RouteSettings) QueryValues(key string) []string {
+	if s.Query == nil {
+		return nil
+	}
+	return s.Query[key]
 }
 
 // Route represents a screen in the navigation stack.

--- a/pkg/navigation/router.go
+++ b/pkg/navigation/router.go
@@ -1,0 +1,481 @@
+package navigation
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/go-drift/drift/pkg/core"
+)
+
+// RouteConfigurer is the interface implemented by route configuration types.
+// The two implementations are [RouteConfig] for regular routes and [ShellRoute]
+// for persistent layouts that wrap child routes.
+type RouteConfigurer interface {
+	routeConfig() // marker method
+}
+
+// RouteConfig defines a single route in the declarative [Router].
+//
+// Path patterns support:
+//   - Static segments: "/products", "/users/list"
+//   - Parameters: "/products/:id", "/users/:userId/posts/:postId"
+//   - Wildcards: "/files/*path" (captures remaining path)
+//
+// Example with nested routes:
+//
+//	navigation.RouteConfig{
+//	    Path:    "/products",
+//	    Builder: buildProductList,
+//	    Routes: []navigation.RouteConfigurer{
+//	        navigation.RouteConfig{
+//	            Path:    "/:id",           // Matches /products/:id
+//	            Builder: buildProductDetail,
+//	        },
+//	        navigation.RouteConfig{
+//	            Path:    "/:id/reviews",   // Matches /products/:id/reviews
+//	            Builder: buildProductReviews,
+//	        },
+//	    },
+//	}
+type RouteConfig struct {
+	// Path is the URL pattern for this route.
+	// Use :param for path parameters and *param for wildcards.
+	// Nested routes inherit the parent's path as a prefix.
+	Path string
+
+	// Builder creates the widget for this route.
+	// RouteSettings includes extracted Params and Query from the URL.
+	Builder func(ctx core.BuildContext, settings RouteSettings) core.Widget
+
+	// Redirect defines route-specific redirect logic.
+	// Checked after the Router's global Redirect callback.
+	// Use for route-specific access control.
+	Redirect func(ctx RedirectContext) RedirectResult
+
+	// Routes defines nested child routes.
+	// Child paths are concatenated with this route's path.
+	Routes []RouteConfigurer
+}
+
+func (RouteConfig) routeConfig() {}
+
+// Router provides declarative route configuration with automatic path matching
+// and parameter extraction.
+//
+// Router is the recommended approach for apps with URL-based routing. It
+// internally creates a [Navigator] with IsRoot=true, so you don't need to
+// manage navigator registration manually.
+//
+// IMPORTANT: Router is designed to be used as a singleton at the root of your
+// app. Do not nest Routers or use Router inside [TabScaffold] tabs. For tabs
+// with their own navigation stacks, use [Navigator] with [Tab.OnGenerateRoute]
+// instead.
+//
+// Basic usage:
+//
+//	navigation.Router{
+//	    InitialPath: "/",
+//	    Routes: []navigation.RouteConfigurer{
+//	        navigation.RouteConfig{Path: "/", Builder: buildHome},
+//	        navigation.RouteConfig{Path: "/products/:id", Builder: buildProduct},
+//	    },
+//	    ErrorBuilder: build404Page,
+//	}
+//
+// With authentication:
+//
+//	navigation.Router{
+//	    InitialPath:       "/",
+//	    RefreshListenable: authState,
+//	    Redirect: func(ctx navigation.RedirectContext) navigation.RedirectResult {
+//	        if !authState.IsLoggedIn() && isProtected(ctx.ToPath) {
+//	            return navigation.RedirectTo("/login")
+//	        }
+//	        return navigation.NoRedirect()
+//	    },
+//	    Routes: routes,
+//	}
+//
+// Access the router for navigation using [RouterOf]:
+//
+//	router := navigation.RouterOf(ctx)
+//	router.Go("/products/123", nil)
+type Router struct {
+	// Routes defines the route tree.
+	// Use [RouteConfig] for regular routes and [ShellRoute] for persistent layouts.
+	Routes []RouteConfigurer
+
+	// Redirect is the global redirect callback, checked before every navigation.
+	// Return [NoRedirect] to allow, or [RedirectTo]/[RedirectWithArgs] to redirect.
+	// Route-specific redirects in [RouteConfig.Redirect] are checked after this.
+	Redirect func(ctx RedirectContext) RedirectResult
+
+	// ErrorBuilder creates a widget for unmatched routes (404 pages).
+	// If nil, navigation to unknown routes is silently ignored.
+	ErrorBuilder func(ctx core.BuildContext, settings RouteSettings) core.Widget
+
+	// InitialPath is the starting route path.
+	// Defaults to "/" if not specified.
+	InitialPath string
+
+	// TrailingSlashBehavior controls how trailing slashes are handled in matching.
+	// Default is [TrailingSlashStrip] which treats "/path/" same as "/path".
+	TrailingSlashBehavior TrailingSlashBehavior
+
+	// CaseSensitivity controls case handling in path matching.
+	// Default is [CaseSensitive] which requires exact case match.
+	CaseSensitivity CaseSensitivity
+
+	// RefreshListenable triggers redirect re-evaluation when notified.
+	// Connect this to auth state changes to automatically redirect users
+	// when they log in or out.
+	RefreshListenable core.Listenable
+}
+
+// CreateElement returns a StatefulElement for this Router.
+func (r Router) CreateElement() core.Element {
+	return core.NewStatefulElement(r, nil)
+}
+
+// Key returns nil (no key).
+func (r Router) Key() any {
+	return nil
+}
+
+// CreateState creates the RouterState.
+func (r Router) CreateState() core.State {
+	return &routerState{}
+}
+
+// RouterState extends [NavigatorState] with path-based navigation methods.
+//
+// Obtain a RouterState using [RouterOf] from within the widget tree.
+// RouterState embeds NavigatorState, so all standard navigation methods
+// (Push, Pop, etc.) are available.
+//
+//	router := navigation.RouterOf(ctx)
+//	router.Go("/products/123", nil)    // Navigate to path
+//	router.Replace("/home", nil)       // Replace current route
+//	router.Pop(nil)                    // Go back
+type RouterState interface {
+	NavigatorState // All NavigatorState methods are available
+
+	// Go navigates to the given path, pushing a new route onto the stack.
+	// Equivalent to PushNamed but with clearer intent for URL-based navigation.
+	Go(path string, args any)
+
+	// Replace replaces the current route with the given path.
+	// The current route is removed and the new route takes its place.
+	// Equivalent to PushReplacementNamed.
+	Replace(path string, args any)
+}
+
+// routeIndex stores compiled route patterns for efficient lookup.
+type routeIndex struct {
+	patterns []*indexedRoute
+}
+
+type indexedRoute struct {
+	pattern  *PathPattern
+	config   RouteConfig
+	fullPath string
+	shells   []ShellRoute // Shell hierarchy from outermost to innermost
+}
+
+type routerState struct {
+	element     *core.StatefulElement
+	router      Router
+	internalNav *navigatorState
+	routeIndex  *routeIndex
+}
+
+func (s *routerState) SetElement(element *core.StatefulElement) {
+	s.element = element
+}
+
+func (s *routerState) InitState() {
+	s.router = s.element.Widget().(Router)
+	s.routeIndex = s.buildRouteIndex()
+}
+
+func (s *routerState) buildRouteIndex() *routeIndex {
+	index := &routeIndex{}
+	s.indexRoutes("", nil, s.router.Routes, index)
+	return index
+}
+
+func (s *routerState) indexRoutes(prefix string, shells []ShellRoute, routes []RouteConfigurer, index *routeIndex) {
+	for _, rc := range routes {
+		switch cfg := rc.(type) {
+		case RouteConfig:
+			fullPath := prefix + cfg.Path
+			pattern := NewPathPattern(
+				fullPath,
+				WithTrailingSlash(s.router.TrailingSlashBehavior),
+				WithCaseSensitivity(s.router.CaseSensitivity),
+			)
+			index.patterns = append(index.patterns, &indexedRoute{
+				pattern:  pattern,
+				config:   cfg,
+				fullPath: fullPath,
+				shells:   shells, // Capture current shell hierarchy
+			})
+
+			// Index nested routes (inherit same shells)
+			if len(cfg.Routes) > 0 {
+				s.indexRoutes(fullPath, shells, cfg.Routes, index)
+			}
+
+		case ShellRoute:
+			// Shell routes add to the shell hierarchy for their children
+			newShells := append([]ShellRoute{}, shells...)
+			newShells = append(newShells, cfg)
+			s.indexRoutes(prefix, newShells, cfg.Routes, index)
+		}
+	}
+}
+
+func (s *routerState) findRoute(path string) (*indexedRoute, RouteSettings) {
+	// Extract query string but preserve path for pattern matching
+	// (patterns handle trailing slash behavior themselves)
+	_, query := ParsePath(path)
+
+	// Get path portion without query/fragment for matching
+	pathOnly := path
+	if idx := strings.IndexAny(path, "?#"); idx >= 0 {
+		pathOnly = path[:idx]
+	}
+
+	for _, ir := range s.routeIndex.patterns {
+		params, ok := ir.pattern.Match(pathOnly)
+		if ok {
+			return ir, RouteSettings{
+				Name:   path,
+				Params: params,
+				Query:  query,
+			}
+		}
+	}
+	return nil, RouteSettings{}
+}
+
+func (s *routerState) generateRoute(settings RouteSettings) Route {
+	ir, matchedSettings := s.findRoute(settings.Name)
+	if ir == nil {
+		return nil
+	}
+
+	// Merge arguments
+	matchedSettings.Arguments = settings.Arguments
+
+	// Capture for closure
+	routeConfig := ir.config
+	shells := ir.shells
+
+	builder := func(ctx core.BuildContext) core.Widget {
+		// Build the route's widget
+		child := routeConfig.Builder(ctx, matchedSettings)
+
+		// Wrap with shells from innermost to outermost
+		// (shells slice is outermost-first, so iterate in reverse)
+		for i := len(shells) - 1; i >= 0; i-- {
+			shell := shells[i]
+			child = shell.Builder(ctx, child)
+		}
+
+		return child
+	}
+
+	return NewMaterialPageRoute(builder, matchedSettings)
+}
+
+func (s *routerState) unknownRoute(settings RouteSettings) Route {
+	if s.router.ErrorBuilder == nil {
+		return nil
+	}
+
+	builder := func(ctx core.BuildContext) core.Widget {
+		return s.router.ErrorBuilder(ctx, settings)
+	}
+
+	return NewMaterialPageRoute(builder, settings)
+}
+
+func (s *routerState) applyRedirect(ctx RedirectContext) RedirectResult {
+	// First check router-level redirect
+	if s.router.Redirect != nil {
+		result := s.router.Redirect(ctx)
+		if result.Path != "" {
+			return result
+		}
+	}
+
+	// Then check route-level redirect
+	ir, _ := s.findRoute(ctx.ToPath)
+	if ir != nil && ir.config.Redirect != nil {
+		return ir.config.Redirect(ctx)
+	}
+
+	return NoRedirect()
+}
+
+func (s *routerState) Build(ctx core.BuildContext) core.Widget {
+	initialPath := s.router.InitialPath
+	if initialPath == "" {
+		initialPath = "/"
+	}
+
+	// Build internal Navigator
+	nav := Navigator{
+		IsRoot:            true,
+		InitialRoute:      initialPath,
+		OnGenerateRoute:   s.generateRoute,
+		OnUnknownRoute:    s.unknownRoute,
+		Redirect:          s.applyRedirect,
+		RefreshListenable: s.router.RefreshListenable,
+	}
+
+	// Wrap in inherited widget for RouterOf access
+	return routerInherited{
+		state: s,
+		child: nav,
+	}
+}
+
+func (s *routerState) SetState(fn func()) {
+	fn()
+	if s.element != nil {
+		s.element.MarkNeedsBuild()
+	}
+}
+
+func (s *routerState) Dispose() {}
+
+func (s *routerState) DidChangeDependencies() {}
+
+func (s *routerState) DidUpdateWidget(oldWidget core.StatefulWidget) {
+	s.router = s.element.Widget().(Router)
+	s.routeIndex = s.buildRouteIndex()
+}
+
+// NavigatorState interface implementation - delegate to RootNavigator
+
+func (s *routerState) Push(route Route) {
+	if nav := RootNavigator(); nav != nil {
+		nav.Push(route)
+	}
+}
+
+func (s *routerState) PushNamed(name string, args any) {
+	if nav := RootNavigator(); nav != nil {
+		nav.PushNamed(name, args)
+	}
+}
+
+func (s *routerState) PushReplacementNamed(name string, args any) {
+	if nav := RootNavigator(); nav != nil {
+		nav.PushReplacementNamed(name, args)
+	}
+}
+
+func (s *routerState) Pop(result any) {
+	if nav := RootNavigator(); nav != nil {
+		nav.Pop(result)
+	}
+}
+
+func (s *routerState) PopUntil(predicate func(Route) bool) {
+	if nav := RootNavigator(); nav != nil {
+		nav.PopUntil(predicate)
+	}
+}
+
+func (s *routerState) PushReplacement(route Route) {
+	if nav := RootNavigator(); nav != nil {
+		nav.PushReplacement(route)
+	}
+}
+
+func (s *routerState) CanPop() bool {
+	if nav := RootNavigator(); nav != nil {
+		return nav.CanPop()
+	}
+	return false
+}
+
+func (s *routerState) MaybePop(result any) bool {
+	if nav := RootNavigator(); nav != nil {
+		return nav.MaybePop(result)
+	}
+	return false
+}
+
+// RouterState-specific methods
+
+// Go navigates to the given path.
+func (s *routerState) Go(path string, args any) {
+	s.PushNamed(path, args)
+}
+
+// Replace replaces the current route with the given path.
+func (s *routerState) Replace(path string, args any) {
+	s.PushReplacementNamed(path, args)
+}
+
+// routerInherited provides RouterState to descendants.
+type routerInherited struct {
+	state *routerState
+	child core.Widget
+}
+
+func (r routerInherited) CreateElement() core.Element {
+	return core.NewInheritedElement(r, nil)
+}
+
+func (r routerInherited) Key() any {
+	return nil
+}
+
+func (r routerInherited) ChildWidget() core.Widget {
+	return r.child
+}
+
+func (r routerInherited) UpdateShouldNotify(oldWidget core.InheritedWidget) bool {
+	if old, ok := oldWidget.(routerInherited); ok {
+		return r.state != old.state
+	}
+	return true
+}
+
+func (r routerInherited) UpdateShouldNotifyDependent(oldWidget core.InheritedWidget, aspects map[any]struct{}) bool {
+	return r.UpdateShouldNotify(oldWidget)
+}
+
+var routerInheritedType = reflect.TypeOf(routerInherited{})
+
+// RouterOf returns the [RouterState] from the nearest [Router] ancestor.
+//
+// Use this for navigation from within the widget tree when you need the
+// Router's path-based methods (Go, Replace). Returns nil if no Router
+// ancestor exists.
+//
+//	func handleProductTap(ctx core.BuildContext, productID string) {
+//	    if router := navigation.RouterOf(ctx); router != nil {
+//	        router.Go("/products/"+productID, nil)
+//	    }
+//	}
+//
+// RouterState embeds [NavigatorState], so you can also use standard methods:
+//
+//	router := navigation.RouterOf(ctx)
+//	router.Pop(nil)  // Go back
+func RouterOf(ctx core.BuildContext) RouterState {
+	inherited := ctx.DependOnInherited(routerInheritedType, nil)
+	if inherited == nil {
+		return nil
+	}
+	if router, ok := inherited.(routerInherited); ok {
+		return router.state
+	}
+	return nil
+}

--- a/pkg/navigation/router_test.go
+++ b/pkg/navigation/router_test.go
@@ -1,0 +1,507 @@
+package navigation
+
+import (
+	"testing"
+
+	"github.com/go-drift/drift/pkg/core"
+)
+
+func TestRouter_RouteIndex_Basic(t *testing.T) {
+	// Create a router state and manually build the index
+	router := Router{
+		Routes: []RouteConfigurer{
+			RouteConfig{Path: "/"},
+			RouteConfig{Path: "/products"},
+			RouteConfig{Path: "/settings"},
+		},
+	}
+
+	state := &routerState{router: router}
+	index := state.buildRouteIndex()
+
+	if len(index.patterns) != 3 {
+		t.Errorf("Expected 3 patterns, got %d", len(index.patterns))
+	}
+
+	// Verify paths are indexed correctly
+	paths := []string{"/", "/products", "/settings"}
+	for i, ir := range index.patterns {
+		if ir.fullPath != paths[i] {
+			t.Errorf("Pattern %d: expected path %q, got %q", i, paths[i], ir.fullPath)
+		}
+	}
+}
+
+func TestRouter_RouteIndex_NestedRoutes(t *testing.T) {
+	router := Router{
+		Routes: []RouteConfigurer{
+			RouteConfig{Path: "/"},
+			RouteConfig{
+				Path: "/products",
+				Routes: []RouteConfigurer{
+					RouteConfig{Path: "/:id"},
+					RouteConfig{Path: "/:id/reviews"},
+				},
+			},
+		},
+	}
+
+	state := &routerState{router: router}
+	index := state.buildRouteIndex()
+
+	if len(index.patterns) != 4 {
+		t.Errorf("Expected 4 patterns (root + products + 2 nested), got %d", len(index.patterns))
+	}
+
+	// Check nested paths are correctly concatenated
+	expectedPaths := map[string]bool{
+		"/":                     true,
+		"/products":             true,
+		"/products/:id":         true,
+		"/products/:id/reviews": true,
+	}
+
+	for _, ir := range index.patterns {
+		if !expectedPaths[ir.fullPath] {
+			t.Errorf("Unexpected path in index: %q", ir.fullPath)
+		}
+		delete(expectedPaths, ir.fullPath)
+	}
+
+	if len(expectedPaths) > 0 {
+		t.Errorf("Missing paths: %v", expectedPaths)
+	}
+}
+
+func TestRouter_RouteIndex_ShellRoute(t *testing.T) {
+	router := Router{
+		Routes: []RouteConfigurer{
+			RouteConfig{Path: "/login"},
+			ShellRoute{
+				Routes: []RouteConfigurer{
+					RouteConfig{Path: "/home"},
+					RouteConfig{Path: "/profile"},
+				},
+			},
+		},
+	}
+
+	state := &routerState{router: router}
+	index := state.buildRouteIndex()
+
+	// ShellRoute doesn't add patterns, just its children
+	if len(index.patterns) != 3 {
+		t.Errorf("Expected 3 patterns, got %d", len(index.patterns))
+	}
+
+	expectedPaths := map[string]bool{
+		"/login":   true,
+		"/home":    true,
+		"/profile": true,
+	}
+
+	for _, ir := range index.patterns {
+		if !expectedPaths[ir.fullPath] {
+			t.Errorf("Unexpected path: %q", ir.fullPath)
+		}
+	}
+}
+
+func TestRouter_FindRoute_Basic(t *testing.T) {
+	router := Router{
+		Routes: []RouteConfigurer{
+			RouteConfig{Path: "/"},
+			RouteConfig{Path: "/products"},
+			RouteConfig{Path: "/products/:id"},
+		},
+	}
+
+	state := &routerState{router: router}
+	state.routeIndex = state.buildRouteIndex()
+
+	tests := []struct {
+		path       string
+		wantMatch  bool
+		wantParams map[string]string
+	}{
+		{"/", true, nil},
+		{"/products", true, nil},
+		{"/products/123", true, map[string]string{"id": "123"}},
+		{"/unknown", false, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			ir, settings := state.findRoute(tt.path)
+			gotMatch := ir != nil
+
+			if gotMatch != tt.wantMatch {
+				t.Errorf("findRoute(%q) match = %v, want %v", tt.path, gotMatch, tt.wantMatch)
+			}
+
+			if tt.wantMatch && tt.wantParams != nil {
+				for k, v := range tt.wantParams {
+					if settings.Params[k] != v {
+						t.Errorf("findRoute(%q) param[%s] = %q, want %q", tt.path, k, settings.Params[k], v)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestRouter_FindRoute_WithQuery(t *testing.T) {
+	router := Router{
+		Routes: []RouteConfigurer{
+			RouteConfig{Path: "/search"},
+		},
+	}
+
+	state := &routerState{router: router}
+	state.routeIndex = state.buildRouteIndex()
+
+	ir, settings := state.findRoute("/search?q=hello&page=2")
+	if ir == nil {
+		t.Fatal("Expected to find /search route")
+	}
+
+	if settings.QueryValue("q") != "hello" {
+		t.Errorf("QueryValue(q) = %q, want hello", settings.QueryValue("q"))
+	}
+	if settings.QueryValue("page") != "2" {
+		t.Errorf("QueryValue(page) = %q, want 2", settings.QueryValue("page"))
+	}
+}
+
+func TestRouter_FindRoute_TrailingSlash(t *testing.T) {
+	// Default behavior: strip trailing slash
+	router := Router{
+		Routes: []RouteConfigurer{
+			RouteConfig{Path: "/products/:id"},
+		},
+	}
+
+	state := &routerState{router: router}
+	state.routeIndex = state.buildRouteIndex()
+
+	ir, _ := state.findRoute("/products/123/")
+	if ir == nil {
+		t.Error("Should match /products/123/ with trailing slash strip")
+	}
+
+	// Strict mode
+	routerStrict := Router{
+		TrailingSlashBehavior: TrailingSlashStrict,
+		Routes: []RouteConfigurer{
+			RouteConfig{Path: "/products/:id"},
+		},
+	}
+
+	stateStrict := &routerState{router: routerStrict}
+	stateStrict.routeIndex = stateStrict.buildRouteIndex()
+
+	ir, _ = stateStrict.findRoute("/products/123/")
+	if ir != nil {
+		t.Error("Should not match /products/123/ with trailing slash strict")
+	}
+
+	ir, _ = stateStrict.findRoute("/products/123")
+	if ir == nil {
+		t.Error("Should match /products/123 without trailing slash")
+	}
+}
+
+func TestRouter_FindRoute_CaseSensitivity(t *testing.T) {
+	// Default: case sensitive
+	router := Router{
+		Routes: []RouteConfigurer{
+			RouteConfig{Path: "/Products"},
+		},
+	}
+
+	state := &routerState{router: router}
+	state.routeIndex = state.buildRouteIndex()
+
+	ir, _ := state.findRoute("/products")
+	if ir != nil {
+		t.Error("Case sensitive: should not match /products for /Products")
+	}
+
+	ir, _ = state.findRoute("/Products")
+	if ir == nil {
+		t.Error("Case sensitive: should match /Products")
+	}
+
+	// Case insensitive
+	routerInsensitive := Router{
+		CaseSensitivity: CaseInsensitive,
+		Routes: []RouteConfigurer{
+			RouteConfig{Path: "/Products"},
+		},
+	}
+
+	stateInsensitive := &routerState{router: routerInsensitive}
+	stateInsensitive.routeIndex = stateInsensitive.buildRouteIndex()
+
+	ir, _ = stateInsensitive.findRoute("/products")
+	if ir == nil {
+		t.Error("Case insensitive: should match /products")
+	}
+}
+
+func TestRouter_ApplyRedirect_GlobalRedirect(t *testing.T) {
+	router := Router{
+		Redirect: func(ctx RedirectContext) RedirectResult {
+			if ctx.ToPath == "/protected" {
+				return RedirectTo("/login")
+			}
+			return NoRedirect()
+		},
+		Routes: []RouteConfigurer{
+			RouteConfig{Path: "/"},
+			RouteConfig{Path: "/login"},
+			RouteConfig{Path: "/protected"},
+		},
+	}
+
+	state := &routerState{router: router}
+	state.routeIndex = state.buildRouteIndex()
+
+	// Protected route should redirect
+	result := state.applyRedirect(RedirectContext{ToPath: "/protected"})
+	if result.Path != "/login" {
+		t.Errorf("Expected redirect to /login, got %q", result.Path)
+	}
+
+	// Non-protected route should not redirect
+	result = state.applyRedirect(RedirectContext{ToPath: "/"})
+	if result.Path != "" {
+		t.Errorf("Expected no redirect, got %q", result.Path)
+	}
+}
+
+func TestRouter_ApplyRedirect_RouteLevel(t *testing.T) {
+	router := Router{
+		Routes: []RouteConfigurer{
+			RouteConfig{Path: "/"},
+			RouteConfig{
+				Path: "/admin",
+				Redirect: func(ctx RedirectContext) RedirectResult {
+					return RedirectTo("/login")
+				},
+			},
+		},
+	}
+
+	state := &routerState{router: router}
+	state.routeIndex = state.buildRouteIndex()
+
+	// /admin has route-level redirect
+	result := state.applyRedirect(RedirectContext{ToPath: "/admin"})
+	if result.Path != "/login" {
+		t.Errorf("Expected redirect to /login, got %q", result.Path)
+	}
+
+	// / has no redirect
+	result = state.applyRedirect(RedirectContext{ToPath: "/"})
+	if result.Path != "" {
+		t.Errorf("Expected no redirect, got %q", result.Path)
+	}
+}
+
+func TestRouter_ApplyRedirect_GlobalOverridesRoute(t *testing.T) {
+	router := Router{
+		Redirect: func(ctx RedirectContext) RedirectResult {
+			// Global redirect always sends to /maintenance
+			return RedirectTo("/maintenance")
+		},
+		Routes: []RouteConfigurer{
+			RouteConfig{
+				Path: "/admin",
+				Redirect: func(ctx RedirectContext) RedirectResult {
+					return RedirectTo("/login")
+				},
+			},
+		},
+	}
+
+	state := &routerState{router: router}
+	state.routeIndex = state.buildRouteIndex()
+
+	// Global redirect takes precedence
+	result := state.applyRedirect(RedirectContext{ToPath: "/admin"})
+	if result.Path != "/maintenance" {
+		t.Errorf("Expected global redirect to /maintenance, got %q", result.Path)
+	}
+}
+
+func TestRouter_DeeplyNestedRoutes(t *testing.T) {
+	router := Router{
+		Routes: []RouteConfigurer{
+			RouteConfig{
+				Path: "/api",
+				Routes: []RouteConfigurer{
+					RouteConfig{
+						Path: "/v1",
+						Routes: []RouteConfigurer{
+							RouteConfig{Path: "/users"},
+							RouteConfig{Path: "/users/:id"},
+						},
+					},
+					RouteConfig{Path: "/v2"},
+				},
+			},
+		},
+	}
+
+	state := &routerState{router: router}
+	state.routeIndex = state.buildRouteIndex()
+
+	tests := []struct {
+		path      string
+		wantMatch bool
+	}{
+		{"/api", true},
+		{"/api/v1", true},
+		{"/api/v1/users", true},
+		{"/api/v1/users/42", true},
+		{"/api/v2", true},
+		{"/api/v3", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			ir, _ := state.findRoute(tt.path)
+			gotMatch := ir != nil
+			if gotMatch != tt.wantMatch {
+				t.Errorf("findRoute(%q) = %v, want %v", tt.path, gotMatch, tt.wantMatch)
+			}
+		})
+	}
+}
+
+func TestRouter_ShellRoute_ShellsTracked(t *testing.T) {
+	router := Router{
+		Routes: []RouteConfigurer{
+			ShellRoute{
+				Builder: func(ctx core.BuildContext, child core.Widget) core.Widget {
+					return child // Simplified for test
+				},
+				Routes: []RouteConfigurer{
+					RouteConfig{Path: "/home"},
+					RouteConfig{Path: "/profile"},
+				},
+			},
+			RouteConfig{Path: "/login"}, // Outside shell
+		},
+	}
+
+	state := &routerState{router: router}
+	state.routeIndex = state.buildRouteIndex()
+
+	// Routes inside shell should have shell tracked
+	ir, _ := state.findRoute("/home")
+	if ir == nil {
+		t.Fatal("Should find /home")
+	}
+	if len(ir.shells) != 1 {
+		t.Errorf("/home should have 1 shell, got %d", len(ir.shells))
+	}
+
+	ir, _ = state.findRoute("/profile")
+	if ir == nil {
+		t.Fatal("Should find /profile")
+	}
+	if len(ir.shells) != 1 {
+		t.Errorf("/profile should have 1 shell, got %d", len(ir.shells))
+	}
+
+	// Route outside shell should have no shells
+	ir, _ = state.findRoute("/login")
+	if ir == nil {
+		t.Fatal("Should find /login")
+	}
+	if len(ir.shells) != 0 {
+		t.Errorf("/login should have 0 shells, got %d", len(ir.shells))
+	}
+}
+
+func TestRouter_ShellRoute_NestedShells(t *testing.T) {
+	router := Router{
+		Routes: []RouteConfigurer{
+			ShellRoute{
+				Builder: func(ctx core.BuildContext, child core.Widget) core.Widget {
+					return child // Outer shell
+				},
+				Routes: []RouteConfigurer{
+					ShellRoute{
+						Builder: func(ctx core.BuildContext, child core.Widget) core.Widget {
+							return child // Inner shell
+						},
+						Routes: []RouteConfigurer{
+							RouteConfig{Path: "/nested"},
+						},
+					},
+					RouteConfig{Path: "/single-shell"},
+				},
+			},
+		},
+	}
+
+	state := &routerState{router: router}
+	state.routeIndex = state.buildRouteIndex()
+
+	// Route in nested shells should have both shells
+	ir, _ := state.findRoute("/nested")
+	if ir == nil {
+		t.Fatal("Should find /nested")
+	}
+	if len(ir.shells) != 2 {
+		t.Errorf("/nested should have 2 shells, got %d", len(ir.shells))
+	}
+
+	// Route in single shell should have 1 shell
+	ir, _ = state.findRoute("/single-shell")
+	if ir == nil {
+		t.Fatal("Should find /single-shell")
+	}
+	if len(ir.shells) != 1 {
+		t.Errorf("/single-shell should have 1 shell, got %d", len(ir.shells))
+	}
+}
+
+func TestRouter_TrailingSlash_RequiresTrailingSlash(t *testing.T) {
+	// In strict mode, pattern ending with / should require trailing slash
+	router := Router{
+		TrailingSlashBehavior: TrailingSlashStrict,
+		Routes: []RouteConfigurer{
+			RouteConfig{Path: "/products/"}, // Requires trailing slash
+			RouteConfig{Path: "/users"},     // No trailing slash
+		},
+	}
+
+	state := &routerState{router: router}
+	state.routeIndex = state.buildRouteIndex()
+
+	// /products/ pattern should match /products/ but not /products
+	ir, _ := state.findRoute("/products/")
+	if ir == nil {
+		t.Error("Should match /products/ with trailing slash")
+	}
+
+	ir, _ = state.findRoute("/products")
+	if ir != nil {
+		t.Error("Should NOT match /products without trailing slash when pattern has it")
+	}
+
+	// /users pattern should match /users but not /users/
+	ir, _ = state.findRoute("/users")
+	if ir == nil {
+		t.Error("Should match /users without trailing slash")
+	}
+
+	ir, _ = state.findRoute("/users/")
+	if ir != nil {
+		t.Error("Should NOT match /users/ with trailing slash when pattern doesn't have it")
+	}
+}

--- a/pkg/navigation/shell_route.go
+++ b/pkg/navigation/shell_route.go
@@ -1,0 +1,34 @@
+package navigation
+
+import "github.com/go-drift/drift/pkg/core"
+
+// ShellRoute wraps child routes in a persistent layout.
+// Use this for layouts like tabs, drawers, or persistent navigation bars
+// that should remain visible while the inner content changes.
+//
+// Example:
+//
+//	ShellRoute{
+//	    Builder: func(ctx core.BuildContext, child core.Widget) core.Widget {
+//	        return widgets.Column{
+//	            Children: []core.Widget{
+//	                MyNavigationBar{},
+//	                widgets.Expanded{Child: child},
+//	            },
+//	        }
+//	    },
+//	    Routes: []navigation.RouteConfigurer{
+//	        navigation.RouteConfig{Path: "/home", Builder: homePage},
+//	        navigation.RouteConfig{Path: "/settings", Builder: settingsPage},
+//	    },
+//	}
+type ShellRoute struct {
+	// Builder creates the shell layout.
+	// The child parameter is the current route's widget.
+	Builder func(ctx core.BuildContext, child core.Widget) core.Widget
+
+	// Routes defines the routes that are wrapped by this shell.
+	Routes []RouteConfigurer
+}
+
+func (ShellRoute) routeConfig() {}

--- a/pkg/navigation/tab_controller_test.go
+++ b/pkg/navigation/tab_controller_test.go
@@ -1,0 +1,101 @@
+package navigation
+
+import (
+	"testing"
+)
+
+func TestNewTabController(t *testing.T) {
+	c := NewTabController(2)
+	if c.Index() != 2 {
+		t.Errorf("Index() = %d, want 2", c.Index())
+	}
+}
+
+func TestTabController_Index_Nil(t *testing.T) {
+	var c *TabController
+	if c.Index() != 0 {
+		t.Errorf("nil.Index() = %d, want 0", c.Index())
+	}
+}
+
+func TestTabController_SetIndex(t *testing.T) {
+	c := NewTabController(0)
+
+	c.SetIndex(2)
+	if c.Index() != 2 {
+		t.Errorf("Index() = %d, want 2", c.Index())
+	}
+
+	c.SetIndex(5)
+	if c.Index() != 5 {
+		t.Errorf("Index() = %d, want 5", c.Index())
+	}
+}
+
+func TestTabController_SetIndex_Nil(t *testing.T) {
+	var c *TabController
+	// Should not panic
+	c.SetIndex(1)
+}
+
+func TestTabController_SetIndex_SameValue(t *testing.T) {
+	c := NewTabController(2)
+
+	called := false
+	c.AddListener(func(index int) {
+		called = true
+	})
+
+	c.SetIndex(2) // Same value
+
+	if called {
+		t.Error("Listener should not be called when setting same index")
+	}
+}
+
+func TestTabController_AddListener(t *testing.T) {
+	c := NewTabController(0)
+
+	var receivedIndex int
+	c.AddListener(func(index int) {
+		receivedIndex = index
+	})
+
+	c.SetIndex(3)
+
+	if receivedIndex != 3 {
+		t.Errorf("Listener received index = %d, want 3", receivedIndex)
+	}
+}
+
+func TestTabController_AddListener_Multiple(t *testing.T) {
+	c := NewTabController(0)
+
+	var count1, count2 int
+	c.AddListener(func(index int) { count1++ })
+	c.AddListener(func(index int) { count2++ })
+
+	c.SetIndex(1)
+	c.SetIndex(2)
+
+	if count1 != 2 || count2 != 2 {
+		t.Errorf("Listeners called %d and %d times, want 2 each", count1, count2)
+	}
+}
+
+func TestTabController_AddListener_Unsubscribe(t *testing.T) {
+	c := NewTabController(0)
+
+	callCount := 0
+	unsub := c.AddListener(func(index int) {
+		callCount++
+	})
+
+	c.SetIndex(1)
+	unsub()
+	c.SetIndex(2)
+
+	if callCount != 1 {
+		t.Errorf("Listener called %d times, want 1 (before unsubscribe)", callCount)
+	}
+}

--- a/pkg/navigation/tab_scaffold.go
+++ b/pkg/navigation/tab_scaffold.go
@@ -1,23 +1,50 @@
 package navigation
 
 import (
+	"reflect"
+
 	"github.com/go-drift/drift/pkg/core"
 	"github.com/go-drift/drift/pkg/layout"
 	"github.com/go-drift/drift/pkg/theme"
 	"github.com/go-drift/drift/pkg/widgets"
 )
 
-// Tab configures a single tab in a TabScaffold.
+// Tab configures a single tab in a [TabScaffold].
+//
+// For simple tabs with a single screen, use [NewTab]. For tabs with their own
+// navigation stack, configure OnGenerateRoute.
 type Tab struct {
-	Item            widgets.TabItem
-	Builder         func(ctx core.BuildContext) core.Widget
-	InitialRoute    string
+	// Item defines the tab's appearance in the tab bar.
+	Item widgets.TabItem
+
+	// Builder creates the tab's root widget.
+	// Used when OnGenerateRoute is nil to create a simple single-screen tab.
+	Builder func(ctx core.BuildContext) core.Widget
+
+	// InitialRoute is the starting route for this tab's navigator.
+	// Defaults to "/" if not specified.
+	InitialRoute string
+
+	// OnGenerateRoute creates routes for this tab's navigation stack.
+	// If nil, a simple navigator is created using Builder for the initial route.
 	OnGenerateRoute func(settings RouteSettings) Route
-	OnUnknownRoute  func(settings RouteSettings) Route
-	Observers       []NavigatorObserver
+
+	// OnUnknownRoute handles navigation to undefined routes within this tab.
+	OnUnknownRoute func(settings RouteSettings) Route
+
+	// Observers receive navigation events for this tab's navigator.
+	Observers []NavigatorObserver
 }
 
 // NewTab creates a Tab with a simple root builder.
+//
+// Use this for tabs that don't need their own navigation stack. For tabs with
+// multiple screens, create a Tab with OnGenerateRoute instead.
+//
+//	navigation.NewTab(
+//	    widgets.TabItem{Label: "Home", Icon: homeIcon},
+//	    buildHomeScreen,
+//	)
 func NewTab(item widgets.TabItem, builder func(ctx core.BuildContext) core.Widget) Tab {
 	return Tab{
 		Item:    item,
@@ -25,9 +52,53 @@ func NewTab(item widgets.TabItem, builder func(ctx core.BuildContext) core.Widge
 	}
 }
 
-// TabScaffold hosts tab navigation with a separate Navigator per tab.
+// TabScaffold provides bottom tab navigation with separate navigation stacks
+// per tab.
+//
+// Each tab has its own [Navigator], allowing independent navigation within tabs.
+// When the user switches tabs, the tab's navigation state is preserved.
+// TabScaffold automatically manages which tab's navigator is "active" for
+// back button handling via [NavigationScope].
+//
+// Basic usage:
+//
+//	navigation.TabScaffold{
+//	    Tabs: []navigation.Tab{
+//	        navigation.NewTab(
+//	            widgets.TabItem{Label: "Home"},
+//	            buildHomeScreen,
+//	        ),
+//	        navigation.NewTab(
+//	            widgets.TabItem{Label: "Profile"},
+//	            buildProfileScreen,
+//	        ),
+//	    },
+//	}
+//
+// With navigation stacks per tab:
+//
+//	navigation.Tab{
+//	    Item:         widgets.TabItem{Label: "Products"},
+//	    InitialRoute: "/products",
+//	    OnGenerateRoute: func(settings navigation.RouteSettings) navigation.Route {
+//	        switch settings.Name {
+//	        case "/products":
+//	            return navigation.NewMaterialPageRoute(buildProductList, settings)
+//	        case "/products/detail":
+//	            return navigation.NewMaterialPageRoute(buildProductDetail, settings)
+//	        }
+//	        return nil
+//	    },
+//	}
+//
+// Accessibility: Inactive tabs are automatically excluded from the accessibility
+// tree using [widgets.ExcludeSemantics].
 type TabScaffold struct {
-	Tabs       []Tab
+	// Tabs defines the tab configuration. At least one tab is required.
+	Tabs []Tab
+
+	// Controller optionally provides programmatic control over tab selection.
+	// If nil, a default controller starting at index 0 is created.
 	Controller *TabController
 }
 
@@ -48,6 +119,8 @@ type tabScaffoldState struct {
 	scaffold              TabScaffold
 	controller            *TabController
 	unsubscribeController func()
+	tabNavigators         []NavigatorState // Store each tab's navigator
+	currentIndex          int              // Track current tab for active navigator
 }
 
 func (s *tabScaffoldState) SetElement(element *core.StatefulElement) {
@@ -56,6 +129,7 @@ func (s *tabScaffoldState) SetElement(element *core.StatefulElement) {
 
 func (s *tabScaffoldState) InitState() {
 	s.scaffold = s.element.Widget().(TabScaffold)
+	s.tabNavigators = make([]NavigatorState, len(s.scaffold.Tabs))
 	s.configureController()
 }
 
@@ -65,12 +139,26 @@ func (s *tabScaffoldState) Build(ctx core.BuildContext) core.Widget {
 	}
 
 	index := s.validatedIndex()
+	s.currentIndex = index
 	tabItems := make([]widgets.TabItem, len(s.scaffold.Tabs))
 	bodies := make([]core.Widget, len(s.scaffold.Tabs))
 
 	for i, tab := range s.scaffold.Tabs {
 		tabItems[i] = tab.Item
-		bodies[i] = s.buildTabNavigator(tab)
+		isActive := i == index
+
+		// Wrap each tab's navigator with registration callback and accessibility handling
+		bodies[i] = widgets.ExcludeSemantics{
+			Excluding: !isActive,
+			Child: widgets.Offstage{
+				Offstage: !isActive,
+				Child: tabNavigatorScope{
+					scaffoldState: s,
+					tabIndex:      i,
+					child:         s.buildTabNavigator(tab),
+				},
+			},
+		}
 	}
 
 	return widgets.Column{
@@ -145,7 +233,19 @@ func (s *tabScaffoldState) Dispose() {
 func (s *tabScaffoldState) DidChangeDependencies() {}
 
 func (s *tabScaffoldState) DidUpdateWidget(oldWidget core.StatefulWidget) {
+	oldScaffold := s.scaffold
 	s.scaffold = s.element.Widget().(TabScaffold)
+
+	// Resize tabNavigators if tab count changed
+	if len(s.scaffold.Tabs) != len(oldScaffold.Tabs) {
+		newNavigators := make([]NavigatorState, len(s.scaffold.Tabs))
+		// Preserve existing navigators where possible
+		for i := 0; i < len(newNavigators) && i < len(s.tabNavigators); i++ {
+			newNavigators[i] = s.tabNavigators[i]
+		}
+		s.tabNavigators = newNavigators
+	}
+
 	s.configureController()
 }
 
@@ -158,7 +258,8 @@ func (s *tabScaffoldState) configureController() {
 	}
 
 	s.controller = controller
-	s.unsubscribeController = s.controller.AddListener(func(_ int) {
+	s.unsubscribeController = s.controller.AddListener(func(index int) {
+		s.onTabChanged(index)
 		s.SetState(func() {})
 	})
 }
@@ -169,4 +270,84 @@ func (s *tabScaffoldState) detachController() {
 		s.unsubscribeController = nil
 	}
 	s.controller = nil
+}
+
+// registerTabNavigator stores a tab's navigator and sets it as active if needed.
+func (s *tabScaffoldState) registerTabNavigator(index int, nav NavigatorState) {
+	if index < 0 || index >= len(s.tabNavigators) {
+		return
+	}
+	s.tabNavigators[index] = nav
+
+	// If this is the active tab, set it as the active navigator
+	if index == s.currentIndex {
+		globalScope.SetActiveNavigator(nav)
+	}
+}
+
+// onTabChanged updates the active navigator when tabs change.
+func (s *tabScaffoldState) onTabChanged(index int) {
+	s.currentIndex = index
+	// Set the active tab's navigator as the focused one
+	if index >= 0 && index < len(s.tabNavigators) && s.tabNavigators[index] != nil {
+		globalScope.SetActiveNavigator(s.tabNavigators[index])
+	}
+}
+
+// tabNavigatorScope provides a way for child navigators to register with TabScaffold.
+type tabNavigatorScope struct {
+	scaffoldState *tabScaffoldState
+	tabIndex      int
+	child         core.Widget
+}
+
+func (t tabNavigatorScope) CreateElement() core.Element {
+	return core.NewInheritedElement(t, nil)
+}
+
+func (t tabNavigatorScope) Key() any {
+	return t.tabIndex
+}
+
+func (t tabNavigatorScope) ChildWidget() core.Widget {
+	return t.child
+}
+
+func (t tabNavigatorScope) UpdateShouldNotify(oldWidget core.InheritedWidget) bool {
+	if old, ok := oldWidget.(tabNavigatorScope); ok {
+		return t.tabIndex != old.tabIndex || t.scaffoldState != old.scaffoldState
+	}
+	return true
+}
+
+func (t tabNavigatorScope) UpdateShouldNotifyDependent(oldWidget core.InheritedWidget, aspects map[any]struct{}) bool {
+	return t.UpdateShouldNotify(oldWidget)
+}
+
+var tabNavigatorScopeType = reflect.TypeOf(tabNavigatorScope{})
+
+// RegisterTabNavigator registers a navigator with its enclosing [TabScaffold].
+//
+// This is called automatically by [Navigator] during Build when inside a
+// TabScaffold. You typically don't need to call this directly.
+//
+// Registration enables TabScaffold to track which navigator is active and
+// should receive back button events.
+func RegisterTabNavigator(ctx core.BuildContext, nav NavigatorState) {
+	tryRegisterTabNavigator(ctx, nav)
+}
+
+// tryRegisterTabNavigator attempts to register a navigator with its enclosing
+// TabScaffold. Returns true if inside a TabScaffold and registration occurred,
+// false otherwise.
+func tryRegisterTabNavigator(ctx core.BuildContext, nav NavigatorState) bool {
+	inherited := ctx.DependOnInherited(tabNavigatorScopeType, nil)
+	if inherited == nil {
+		return false
+	}
+	if scope, ok := inherited.(tabNavigatorScope); ok {
+		scope.scaffoldState.registerTabNavigator(scope.tabIndex, nav)
+		return true
+	}
+	return false
 }

--- a/pkg/navigation/tab_scaffold_test.go
+++ b/pkg/navigation/tab_scaffold_test.go
@@ -1,0 +1,326 @@
+package navigation
+
+import (
+	"testing"
+
+	"github.com/go-drift/drift/pkg/widgets"
+)
+
+func TestTabScaffoldState_RegisterTabNavigator(t *testing.T) {
+	// Save and restore global state
+	oldScope := globalScope
+	globalScope = &NavigationScope{}
+	defer func() { globalScope = oldScope }()
+
+	state := &tabScaffoldState{
+		tabNavigators: make([]NavigatorState, 3),
+		currentIndex:  0,
+	}
+
+	nav0 := &mockNavigatorState{}
+	nav1 := &mockNavigatorState{}
+	nav2 := &mockNavigatorState{}
+
+	// Register first tab - should become active since currentIndex is 0
+	state.registerTabNavigator(0, nav0)
+	if state.tabNavigators[0] != nav0 {
+		t.Error("Tab 0 navigator not stored")
+	}
+	if globalScope.ActiveNavigator() != nav0 {
+		t.Error("Tab 0 should be set as active navigator")
+	}
+
+	// Register other tabs - should not change active
+	state.registerTabNavigator(1, nav1)
+	state.registerTabNavigator(2, nav2)
+	if globalScope.ActiveNavigator() != nav0 {
+		t.Error("Active navigator should still be nav0")
+	}
+}
+
+func TestTabScaffoldState_RegisterTabNavigator_InvalidIndex(t *testing.T) {
+	state := &tabScaffoldState{
+		tabNavigators: make([]NavigatorState, 2),
+		currentIndex:  0,
+	}
+
+	nav := &mockNavigatorState{}
+
+	// Out of bounds indices should be silently ignored
+	state.registerTabNavigator(-1, nav)
+	state.registerTabNavigator(5, nav)
+
+	// No panic, no modifications
+	if state.tabNavigators[0] != nil || state.tabNavigators[1] != nil {
+		t.Error("Invalid indices should not modify navigators")
+	}
+}
+
+func TestTabScaffoldState_OnTabChanged(t *testing.T) {
+	// Save and restore global state
+	oldScope := globalScope
+	globalScope = &NavigationScope{}
+	defer func() { globalScope = oldScope }()
+
+	nav0 := &mockNavigatorState{}
+	nav1 := &mockNavigatorState{}
+	nav2 := &mockNavigatorState{}
+
+	state := &tabScaffoldState{
+		tabNavigators: []NavigatorState{nav0, nav1, nav2},
+		currentIndex:  0,
+	}
+
+	// Switch to tab 1
+	state.onTabChanged(1)
+	if state.currentIndex != 1 {
+		t.Errorf("currentIndex = %d, want 1", state.currentIndex)
+	}
+	if globalScope.ActiveNavigator() != nav1 {
+		t.Error("Active navigator should be nav1 after switching to tab 1")
+	}
+
+	// Switch to tab 2
+	state.onTabChanged(2)
+	if state.currentIndex != 2 {
+		t.Errorf("currentIndex = %d, want 2", state.currentIndex)
+	}
+	if globalScope.ActiveNavigator() != nav2 {
+		t.Error("Active navigator should be nav2 after switching to tab 2")
+	}
+
+	// Switch back to tab 0
+	state.onTabChanged(0)
+	if globalScope.ActiveNavigator() != nav0 {
+		t.Error("Active navigator should be nav0 after switching to tab 0")
+	}
+}
+
+func TestTabScaffoldState_OnTabChanged_NilNavigator(t *testing.T) {
+	// Save and restore global state
+	oldScope := globalScope
+	globalScope = &NavigationScope{}
+	defer func() { globalScope = oldScope }()
+
+	nav0 := &mockNavigatorState{}
+
+	state := &tabScaffoldState{
+		tabNavigators: []NavigatorState{nav0, nil, nil}, // Tab 1 and 2 not yet registered
+		currentIndex:  0,
+	}
+
+	// Initially set nav0 as active
+	globalScope.SetActiveNavigator(nav0)
+
+	// Switch to tab 1 (nil navigator)
+	state.onTabChanged(1)
+	if state.currentIndex != 1 {
+		t.Errorf("currentIndex = %d, want 1", state.currentIndex)
+	}
+	// Active navigator should remain unchanged when tab has nil navigator
+	if globalScope.ActiveNavigator() != nav0 {
+		t.Error("Active navigator should remain nav0 when switching to tab with nil navigator")
+	}
+}
+
+func TestTabScaffoldState_OnTabChanged_OutOfBounds(t *testing.T) {
+	// Save and restore global state
+	oldScope := globalScope
+	globalScope = &NavigationScope{}
+	defer func() { globalScope = oldScope }()
+
+	nav0 := &mockNavigatorState{}
+
+	state := &tabScaffoldState{
+		tabNavigators: []NavigatorState{nav0},
+		currentIndex:  0,
+	}
+
+	globalScope.SetActiveNavigator(nav0)
+
+	// Out of bounds - should update currentIndex but not crash or change active
+	state.onTabChanged(5)
+	if state.currentIndex != 5 {
+		t.Errorf("currentIndex = %d, want 5", state.currentIndex)
+	}
+	// Active should remain unchanged
+	if globalScope.ActiveNavigator() != nav0 {
+		t.Error("Active navigator should remain nav0 for out of bounds index")
+	}
+}
+
+func TestTabScaffoldState_ValidatedIndex(t *testing.T) {
+	controller := NewTabController(5) // Start at invalid index
+
+	state := &tabScaffoldState{
+		scaffold: TabScaffold{
+			Tabs: []Tab{
+				{Item: widgets.TabItem{Label: "Tab 0"}},
+				{Item: widgets.TabItem{Label: "Tab 1"}},
+			},
+		},
+		controller: controller,
+	}
+
+	// Index 5 is out of bounds (only 2 tabs), should clamp to 0
+	index := state.validatedIndex()
+	if index != 0 {
+		t.Errorf("validatedIndex() = %d, want 0 for out of bounds index", index)
+	}
+	if controller.Index() != 0 {
+		t.Errorf("Controller index should be reset to 0, got %d", controller.Index())
+	}
+}
+
+func TestTabScaffoldState_ValidatedIndex_Negative(t *testing.T) {
+	controller := NewTabController(-1)
+
+	state := &tabScaffoldState{
+		scaffold: TabScaffold{
+			Tabs: []Tab{
+				{Item: widgets.TabItem{Label: "Tab 0"}},
+			},
+		},
+		controller: controller,
+	}
+
+	index := state.validatedIndex()
+	if index != 0 {
+		t.Errorf("validatedIndex() = %d, want 0 for negative index", index)
+	}
+}
+
+func TestTabScaffoldState_ValidatedIndex_Valid(t *testing.T) {
+	controller := NewTabController(1)
+
+	state := &tabScaffoldState{
+		scaffold: TabScaffold{
+			Tabs: []Tab{
+				{Item: widgets.TabItem{Label: "Tab 0"}},
+				{Item: widgets.TabItem{Label: "Tab 1"}},
+				{Item: widgets.TabItem{Label: "Tab 2"}},
+			},
+		},
+		controller: controller,
+	}
+
+	index := state.validatedIndex()
+	if index != 1 {
+		t.Errorf("validatedIndex() = %d, want 1", index)
+	}
+	// Controller should not be modified
+	if controller.Index() != 1 {
+		t.Errorf("Controller index should remain 1, got %d", controller.Index())
+	}
+}
+
+func TestTabScaffoldState_DidUpdateWidget_ResizesNavigators(t *testing.T) {
+	nav0 := &mockNavigatorState{}
+	nav1 := &mockNavigatorState{}
+
+	// Initial state with 2 tabs
+	state := &tabScaffoldState{
+		scaffold: TabScaffold{
+			Tabs: []Tab{
+				{Item: widgets.TabItem{Label: "Tab 0"}},
+				{Item: widgets.TabItem{Label: "Tab 1"}},
+			},
+		},
+		tabNavigators: []NavigatorState{nav0, nav1},
+		controller:    NewTabController(0),
+	}
+
+	// Simulate widget update with more tabs
+	newScaffold := TabScaffold{
+		Tabs: []Tab{
+			{Item: widgets.TabItem{Label: "Tab 0"}},
+			{Item: widgets.TabItem{Label: "Tab 1"}},
+			{Item: widgets.TabItem{Label: "Tab 2"}},
+			{Item: widgets.TabItem{Label: "Tab 3"}},
+		},
+		Controller: state.controller,
+	}
+
+	// Call DidUpdateWidget with new scaffold
+	oldScaffold := state.scaffold
+	state.scaffold = newScaffold
+
+	// Manually resize (mimicking DidUpdateWidget logic)
+	if len(state.scaffold.Tabs) != len(oldScaffold.Tabs) {
+		newNavigators := make([]NavigatorState, len(state.scaffold.Tabs))
+		for i := 0; i < len(newNavigators) && i < len(state.tabNavigators); i++ {
+			newNavigators[i] = state.tabNavigators[i]
+		}
+		state.tabNavigators = newNavigators
+	}
+
+	// Verify resize happened
+	if len(state.tabNavigators) != 4 {
+		t.Errorf("tabNavigators should have 4 slots, got %d", len(state.tabNavigators))
+	}
+
+	// Verify existing navigators preserved
+	if state.tabNavigators[0] != nav0 {
+		t.Error("Tab 0 navigator should be preserved")
+	}
+	if state.tabNavigators[1] != nav1 {
+		t.Error("Tab 1 navigator should be preserved")
+	}
+
+	// New slots should be nil
+	if state.tabNavigators[2] != nil {
+		t.Error("Tab 2 navigator should be nil")
+	}
+	if state.tabNavigators[3] != nil {
+		t.Error("Tab 3 navigator should be nil")
+	}
+}
+
+func TestTabScaffoldState_DidUpdateWidget_ShrinksTabs(t *testing.T) {
+	nav0 := &mockNavigatorState{}
+	nav1 := &mockNavigatorState{}
+	nav2 := &mockNavigatorState{}
+
+	// Initial state with 3 tabs
+	state := &tabScaffoldState{
+		scaffold: TabScaffold{
+			Tabs: []Tab{
+				{Item: widgets.TabItem{Label: "Tab 0"}},
+				{Item: widgets.TabItem{Label: "Tab 1"}},
+				{Item: widgets.TabItem{Label: "Tab 2"}},
+			},
+		},
+		tabNavigators: []NavigatorState{nav0, nav1, nav2},
+		controller:    NewTabController(0),
+	}
+
+	// Simulate widget update with fewer tabs
+	newScaffold := TabScaffold{
+		Tabs: []Tab{
+			{Item: widgets.TabItem{Label: "Tab 0"}},
+		},
+		Controller: state.controller,
+	}
+
+	// Call DidUpdateWidget logic
+	oldScaffold := state.scaffold
+	state.scaffold = newScaffold
+
+	if len(state.scaffold.Tabs) != len(oldScaffold.Tabs) {
+		newNavigators := make([]NavigatorState, len(state.scaffold.Tabs))
+		for i := 0; i < len(newNavigators) && i < len(state.tabNavigators); i++ {
+			newNavigators[i] = state.tabNavigators[i]
+		}
+		state.tabNavigators = newNavigators
+	}
+
+	// Verify resize happened
+	if len(state.tabNavigators) != 1 {
+		t.Errorf("tabNavigators should have 1 slot, got %d", len(state.tabNavigators))
+	}
+
+	// Verify first navigator preserved
+	if state.tabNavigators[0] != nav0 {
+		t.Error("Tab 0 navigator should be preserved")
+	}
+}

--- a/website-docs/guides/navigation.md
+++ b/website-docs/guides/navigation.md
@@ -6,7 +6,7 @@ sidebar_position: 9
 
 # Navigation
 
-Drift provides stack-based navigation with support for named routes, deep linking, and tab navigation.
+Drift provides stack-based navigation with support for named routes, route guards, path parameters, deep linking, and tab navigation.
 
 ## Setting Up Routes
 
@@ -16,6 +16,7 @@ Use a Navigator with route generation:
 func App() core.Widget {
     return navigation.Navigator{
         InitialRoute: "/",
+        IsRoot:       true, // Mark as root navigator for back button handling
         OnGenerateRoute: func(settings navigation.RouteSettings) navigation.Route {
             switch settings.Name {
             case "/":
@@ -31,6 +32,10 @@ func App() core.Widget {
     }
 }
 ```
+
+### Navigator Ownership
+
+When using multiple navigators (e.g., with TabScaffold), set `IsRoot: true` on your main navigator. This registers it as the root navigator for back button handling and deep links. Tab navigators automatically register with TabScaffold and become active when their tab is selected.
 
 ## Route Builders
 
@@ -190,6 +195,221 @@ navigation.Navigator{
 }
 ```
 
+## Route Guards
+
+Use the `Redirect` callback to implement authentication guards and route protection:
+
+```go
+// Auth state controller
+type AuthState struct {
+    core.ControllerBase
+    isLoggedIn bool
+}
+
+func (a *AuthState) SetLoggedIn(loggedIn bool) {
+    a.isLoggedIn = loggedIn
+    a.NotifyListeners() // Triggers redirect re-evaluation
+}
+
+var authState = &AuthState{}
+
+func App() core.Widget {
+    return navigation.Navigator{
+        InitialRoute:      "/",
+        IsRoot:            true,
+        RefreshListenable: authState, // Re-evaluate redirects when auth changes
+        Redirect: func(ctx navigation.RedirectContext) navigation.RedirectResult {
+            isProtected := strings.HasPrefix(ctx.ToPath, "/dashboard") ||
+                          strings.HasPrefix(ctx.ToPath, "/settings")
+
+            if isProtected && !authState.isLoggedIn {
+                // Redirect to login, preserving the intended destination
+                return navigation.RedirectWithArgs("/login", map[string]any{
+                    "returnTo": ctx.ToPath,
+                })
+            }
+
+            if ctx.ToPath == "/login" && authState.isLoggedIn {
+                // Already logged in, go to dashboard
+                return navigation.RedirectTo("/dashboard")
+            }
+
+            return navigation.NoRedirect()
+        },
+        OnGenerateRoute: generateRoute,
+    }
+}
+```
+
+### Redirect Helpers
+
+| Function | Description |
+|----------|-------------|
+| `NoRedirect()` | Allow navigation to proceed normally |
+| `RedirectTo(path)` | Redirect to a different path (replaces current route) |
+| `RedirectWithArgs(path, args)` | Redirect with arguments preserved |
+
+### RefreshListenable
+
+The `RefreshListenable` field accepts any `core.Listenable`. When the listenable notifies, the navigator re-evaluates whether the current route should be redirected. This is useful for:
+
+- Auth state changes (logout redirects to login)
+- Permission changes (user loses access to a route)
+- Feature flags (route becomes unavailable)
+
+## Path Parameters
+
+Extract dynamic values from URL paths using RouteSettings:
+
+```go
+// Route settings now include Params and Query
+type RouteSettings struct {
+    Name      string
+    Arguments any
+    Params    map[string]string    // Path params like {"id": "123"}
+    Query     map[string][]string  // Query params
+}
+
+// Convenience methods
+settings.Param("id")           // Get path parameter
+settings.QueryValue("search")  // Get first query value
+settings.QueryValues("tags")   // Get all query values
+```
+
+### Using PathPattern
+
+For manual path matching with parameters:
+
+```go
+pattern := navigation.NewPathPattern("/products/:id")
+
+params, ok := pattern.Match("/products/123")
+// params = {"id": "123"}, ok = true
+
+params, ok = pattern.Match("/products/hello%20world")
+// params = {"id": "hello world"}, ok = true (percent-decoded)
+```
+
+### Wildcard Parameters
+
+Capture the rest of the path:
+
+```go
+pattern := navigation.NewPathPattern("/files/*path")
+
+params, ok := pattern.Match("/files/docs/readme.md")
+// params = {"path": "docs/readme.md"}, ok = true
+```
+
+### Path Matching Options
+
+```go
+// Case-insensitive matching
+pattern := navigation.NewPathPattern("/Products/:id",
+    navigation.WithCaseSensitivity(navigation.CaseInsensitive),
+)
+
+// Strict trailing slash
+pattern := navigation.NewPathPattern("/products/:id",
+    navigation.WithTrailingSlash(navigation.TrailingSlashStrict),
+)
+```
+
+### Parsing URLs
+
+Parse full URLs with query strings:
+
+```go
+path, query := navigation.ParsePath("/search?q=drift&page=2")
+// path = "/search"
+// query = {"q": ["drift"], "page": ["2"]}
+```
+
+## Declarative Router
+
+For larger applications, use the declarative `Router` API for cleaner route configuration:
+
+```go
+func App() core.Widget {
+    return navigation.Router{
+        InitialPath: "/",
+        Routes: []navigation.RouteConfigurer{
+            navigation.RouteConfig{
+                Path:    "/",
+                Builder: buildHome,
+            },
+            navigation.RouteConfig{
+                Path:    "/products",
+                Builder: buildProductList,
+                Routes: []navigation.RouteConfigurer{
+                    navigation.RouteConfig{
+                        Path:    "/:id", // Nested: /products/:id
+                        Builder: buildProductDetail,
+                    },
+                },
+            },
+            navigation.RouteConfig{
+                Path:    "/settings",
+                Builder: buildSettings,
+            },
+        },
+        ErrorBuilder: buildNotFound,
+        Redirect:     authRedirect,
+    }
+}
+
+func buildProductDetail(ctx core.BuildContext, settings navigation.RouteSettings) core.Widget {
+    productID := settings.Param("id")
+    return ProductDetailPage{ID: productID}
+}
+```
+
+### RouterState
+
+Access the router for path-based navigation:
+
+```go
+func handleTap(ctx core.BuildContext) {
+    router := navigation.RouterOf(ctx)
+    if router == nil {
+        return
+    }
+
+    // Navigate to a path
+    router.Go("/products/123", nil)
+
+    // Replace current route
+    router.Replace("/settings", nil)
+}
+```
+
+### Shell Routes
+
+Wrap routes in a persistent layout (tabs, sidebars, etc.):
+
+```go
+navigation.Router{
+    Routes: []navigation.RouteConfigurer{
+        navigation.ShellRoute{
+            Builder: func(ctx core.BuildContext, child core.Widget) core.Widget {
+                return widgets.Column{
+                    Children: []core.Widget{
+                        MyNavigationBar{},
+                        widgets.Expanded{Child: child},
+                    },
+                }
+            },
+            Routes: []navigation.RouteConfigurer{
+                navigation.RouteConfig{Path: "/home", Builder: buildHome},
+                navigation.RouteConfig{Path: "/profile", Builder: buildProfile},
+            },
+        },
+        // Routes outside the shell
+        navigation.RouteConfig{Path: "/login", Builder: buildLogin},
+    },
+}
+```
+
 ## Deep Linking
 
 Handle URLs from outside your app using `DeepLinkController`.
@@ -240,7 +460,21 @@ func (s *appState) InitState() {
 The controller automatically:
 - Listens for incoming deep links from the platform
 - Handles the initial deep link if the app was launched via URL
-- Navigates to matching routes using `GlobalNavigator()`
+- Navigates to matching routes using `RootNavigator()`
+
+**Important:** Deep links require a root navigator. If your app uses TabScaffold at the top level, wrap it in a Router:
+
+```go
+navigation.Router{
+    InitialPath: "/",
+    Routes: []navigation.RouteConfigurer{
+        navigation.RouteConfig{Path: "/", Builder: buildTabScaffold},
+        // Deep link routes
+        navigation.RouteConfig{Path: "/product/:id", Builder: buildProduct},
+        navigation.RouteConfig{Path: "/profile/:username", Builder: buildProfile},
+    },
+}
+```
 
 ## Tab Navigation
 
@@ -278,6 +512,15 @@ func buildProfileScreen(ctx core.BuildContext) core.Widget {
     return ProfileScreen{}
 }
 ```
+
+### Active Navigator Tracking
+
+TabScaffold automatically manages which tab's navigator is "active" for back button handling:
+
+- Each tab has its own navigation stack
+- When switching tabs, the new tab's navigator becomes active
+- Back button pops from the active tab's stack
+- Inactive tabs are excluded from the accessibility tree
 
 ### Tab Controller
 
@@ -330,7 +573,7 @@ navigation.Tab{
 
 ## Platform Back Button
 
-The Navigator automatically handles the platform back button. Use `navigation.HandleBackButton()` or `navigation.GlobalNavigator()` for custom back button handling:
+The Navigator automatically handles the platform back button. Use `navigation.HandleBackButton()` for standard back button handling:
 
 ```go
 // In your platform-specific code, call HandleBackButton
@@ -339,23 +582,34 @@ handled := navigation.HandleBackButton()
 if !handled {
     // At root - maybe show exit confirmation or exit app
 }
+```
 
-// Or get the global navigator directly
-if nav := navigation.GlobalNavigator(); nav != nil {
-    if nav.CanPop() {
-        nav.Pop(nil)
-    }
+### Navigation from Outside the Widget Tree
+
+For deep links and external navigation, use `RootNavigator()`:
+
+```go
+// Deep link handler
+if nav := navigation.RootNavigator(); nav != nil {
+    nav.PushNamed("/product", map[string]any{"id": productID})
 }
+```
+
+For back button handling, use `HandleBackButton()` which automatically handles active tab navigation:
+
+```go
+handled := navigation.HandleBackButton()
 ```
 
 ## Nested Navigators
 
-Use multiple navigators for complex flows:
+Use multiple navigators for complex flows. Only the root navigator should have `IsRoot: true`:
 
 ```go
-// Main app navigator
+// Main app navigator (root)
 navigation.Navigator{
     InitialRoute: "/",
+    IsRoot:       true, // Only the root navigator sets this
     OnGenerateRoute: func(settings navigation.RouteSettings) navigation.Route {
         switch settings.Name {
         case "/":
@@ -368,10 +622,11 @@ navigation.Navigator{
     },
 }
 
-// Onboarding flow with its own navigator
+// Onboarding flow with its own navigator (nested, not root)
 func buildOnboarding(ctx core.BuildContext) core.Widget {
     return navigation.Navigator{
         InitialRoute: "/welcome",
+        // IsRoot: false (default) - nested navigators don't register globally
         OnGenerateRoute: func(settings navigation.RouteSettings) navigation.Route {
             switch settings.Name {
             case "/welcome":
@@ -382,6 +637,28 @@ func buildOnboarding(ctx core.BuildContext) core.Widget {
                 return navigation.NewMaterialPageRoute(buildComplete, settings)
             }
             return nil
+        },
+    }
+}
+```
+
+### Back Button with Nested Navigators
+
+For nested navigators outside TabScaffold, back button handling uses the root navigator by default. The nested navigator handles its own internal navigation via `NavigatorOf(ctx)`:
+
+```go
+func buildOnboardingStep(ctx core.BuildContext) core.Widget {
+    return widgets.Column{
+        Children: []core.Widget{
+            widgets.Text{Content: "Step 1"},
+            theme.ButtonOf(ctx, "Next", func() {
+                // Use NavigatorOf for internal navigation within the nested navigator
+                navigation.NavigatorOf(ctx).PushNamed("/setup", nil)
+            }),
+            theme.ButtonOf(ctx, "Skip", func() {
+                // Pop the entire onboarding flow from the root navigator
+                navigation.RootNavigator().Pop(nil)
+            }),
         },
     }
 }


### PR DESCRIPTION
Introduce a declarative Router component as an alternative to imperative Navigator:
- PathPattern for URL matching with :params and *wildcards
- RouteConfig and ShellRoute for declarative route definitions
- Automatic path parameter and query string extraction in RouteSettings
- Redirect callbacks for authentication/authorization guards
- RefreshListenable for re-evaluating guards on auth state changes

Refactor navigator hierarchy management:
- NavigationScope tracks root and active navigators
- RootNavigator() replaces GlobalNavigator() for deep link handling
- TabScaffold integrates with NavigationScope for back button handling
- IsRoot flag distinguishes main navigator from nested tab navigators