### PR TITLE
feat(widgets): add bottom sheet component with navigation integration

### DIFF
--- a/docs/bottom-sheet-scroll-limitation.md
+++ b/docs/bottom-sheet-scroll-limitation.md
@@ -1,0 +1,37 @@
+# Bottom Sheet Scrolling Model
+
+## Summary
+
+The bottom sheet implementation now uses a dedicated render layout that sizes the
+content viewport based on the *current* sheet extent. This fixes the previous
+scroll limitation where the ListView viewport was pinned to the initial snap height.
+
+## Key Behavior
+
+- Snap points are defined as fractions of **available height** (screen minus safe area insets).
+- The sheet extent is stored in pixels and drives layout directly.
+- The content viewport height is computed as:
+
+```
+contentViewport = currentExtent - handleHeight
+```
+
+- The sheet background extends into the bottom safe area, but content does not.
+- Dragging and snapping are independent of content size.
+
+## Why This Fixes Scrolling
+
+Scroll views compute their max scroll extent based on their viewport height.
+By making the viewport height equal to the *current* sheet extent, the scroll
+range grows when the sheet expands. This means:
+
+- At 50% snap, the list scrolls within 50% viewport.
+- At 100% snap, the list scrolls within full viewport.
+
+No flex wrappers, Expanded/Flexible hacks, or forced constraints are required.
+
+## Related Files
+
+- `pkg/widgets/bottom_sheet.go`
+- `pkg/widgets/bottom_sheet_layout.go`
+- `pkg/widgets/bottom_sheet_drag.go`

--- a/pkg/navigation/bottom_sheet_route.go
+++ b/pkg/navigation/bottom_sheet_route.go
@@ -1,0 +1,415 @@
+package navigation
+
+import (
+	"sync"
+
+	"github.com/go-drift/drift/pkg/core"
+	"github.com/go-drift/drift/pkg/graphics"
+	"github.com/go-drift/drift/pkg/overlay"
+	"github.com/go-drift/drift/pkg/theme"
+	"github.com/go-drift/drift/pkg/widgets"
+)
+
+// BottomSheetRoute displays content as a modal bottom sheet.
+// The sheet slides up from the bottom and can be dismissed by dragging down
+// or tapping the barrier (if enabled).
+type BottomSheetRoute struct {
+	BaseRoute
+	builder func(ctx core.BuildContext) core.Widget
+
+	// SnapPoints defines heights where the sheet can rest.
+	// If empty, defaults to [widgets.DefaultSnapPoints].
+	SnapPoints []widgets.SnapPoint
+
+	// InitialSnapPoint is the index into SnapPoints where the sheet starts.
+	// Invalid values are clamped to valid range.
+	InitialSnapPoint int
+
+	// BarrierDismissible controls whether tapping the barrier dismisses the sheet.
+	// Defaults to true.
+	BarrierDismissible bool
+
+	// BarrierColor is the color of the semi-transparent barrier behind the sheet.
+	// If nil, uses theme default.
+	BarrierColor *graphics.Color
+
+	// EnableDrag controls whether the sheet can be dragged.
+	// Defaults to true.
+	EnableDrag bool
+
+	// DragMode controls how drag gestures interact with sheet content.
+	// Defaults to DragModeAuto.
+	DragMode widgets.DragMode
+
+	// ShowHandle controls whether a drag handle is displayed at the top of the sheet.
+	// Defaults to true.
+	ShowHandle bool
+
+	// UseSafeArea controls whether the sheet respects the bottom safe area inset.
+	// Defaults to true.
+	UseSafeArea bool
+
+	// SnapBehavior customizes snapping and dismiss thresholds.
+	SnapBehavior widgets.SnapBehavior
+
+	// internal
+	overlayState   OverlayState
+	barrierEntry   *overlay.OverlayEntry
+	sheetEntry     *overlay.OverlayEntry
+	controller     *widgets.BottomSheetController
+	progressRemove func()
+	didPushPending bool
+	poppedFromNav  bool
+	pushingNav     NavigatorState
+	onDismiss      func(any)
+	dismissed      bool
+	mu             sync.Mutex
+}
+
+// NewBottomSheetRoute creates a new BottomSheetRoute with sensible defaults.
+func NewBottomSheetRoute(
+	builder func(ctx core.BuildContext) core.Widget,
+	settings RouteSettings,
+) *BottomSheetRoute {
+	return &BottomSheetRoute{
+		BaseRoute:          NewBaseRoute(settings),
+		builder:            builder,
+		SnapPoints:         nil, // Will use defaults
+		InitialSnapPoint:   0,
+		BarrierDismissible: true,
+		BarrierColor:       nil, // Will use theme
+		EnableDrag:         true,
+		DragMode:           widgets.DragModeAuto,
+		ShowHandle:         true,
+		UseSafeArea:        true,
+	}
+}
+
+// SetOverlay is called by Navigator when OverlayState becomes available.
+func (r *BottomSheetRoute) SetOverlay(o OverlayState) {
+	wasNil := r.overlayState == nil
+	r.overlayState = o
+	// If DidPush was called before overlay was ready, insert entries now
+	if wasNil && r.didPushPending {
+		r.didPushPending = false
+		r.insertEntries()
+	}
+}
+
+// DidPush is called when the route is pushed onto the navigator.
+func (r *BottomSheetRoute) DidPush() {
+	if r.pushingNav == nil {
+		r.pushingNav = globalScope.ActiveNavigator()
+	}
+	if r.overlayState == nil {
+		// Overlay not ready yet - defer entry insertion
+		r.didPushPending = true
+		return
+	}
+	r.insertEntries()
+}
+
+func (r *BottomSheetRoute) insertEntries() {
+	// Create the controller for this sheet
+	r.controller = widgets.NewBottomSheetController()
+
+	// Create barrier entry - color resolved inside builder to access theme
+	r.barrierEntry = overlay.NewOverlayEntry(func(ctx core.BuildContext) core.Widget {
+		// Get barrier color from route or theme
+		themeData := theme.ThemeOf(ctx).BottomSheetThemeOf()
+		barrierColor := themeData.BarrierColor
+		if r.BarrierColor != nil {
+			barrierColor = *r.BarrierColor // Route override wins
+		}
+		if r.controller != nil {
+			alpha := barrierColor.Alpha() * r.controller.Progress()
+			barrierColor = barrierColor.WithAlpha(alpha)
+		}
+
+		return overlay.ModalBarrier{
+			Color:       barrierColor,
+			Dismissible: r.BarrierDismissible,
+			// Barrier tap triggers animated dismiss via controller
+			OnDismiss:     func() { r.controller.Close(nil) },
+			SemanticLabel: "Dismiss bottom sheet",
+		}
+	})
+	r.barrierEntry.Opaque = false // Don't block hit testing everywhere
+
+	// Create sheet entry - positioned at bottom, animates height
+	r.sheetEntry = overlay.NewOverlayEntry(func(ctx core.BuildContext) core.Widget {
+		// Get theme for the sheet
+		themeData := theme.ThemeOf(ctx).BottomSheetThemeOf()
+		sheetTheme := widgets.BottomSheetTheme{
+			BackgroundColor:     themeData.BackgroundColor,
+			HandleColor:         themeData.HandleColor,
+			BorderRadius:        themeData.BorderRadius,
+			HandleWidth:         themeData.HandleWidth,
+			HandleHeight:        themeData.HandleHeight,
+			HandleTopPadding:    themeData.HandleTopPadding,
+			HandleBottomPadding: themeData.HandleBottomPadding,
+		}
+
+		return widgets.BottomSheet{
+			Builder:      r.builder,
+			Controller:   r.controller,
+			SnapPoints:   r.SnapPoints,
+			InitialSnap:  r.InitialSnapPoint,
+			EnableDrag:   r.EnableDrag,
+			DragMode:     r.DragMode,
+			ShowHandle:   r.ShowHandle,
+			UseSafeArea:  r.UseSafeArea,
+			Theme:        sheetTheme,
+			SnapBehavior: r.SnapBehavior,
+			// Called when dismiss animation completes
+			OnDismiss: r.onAnimationComplete,
+		}
+	})
+	r.sheetEntry.Opaque = true // Block hit testing below when in sheet area
+
+	if r.controller != nil {
+		r.progressRemove = r.controller.AddProgressListener(func(float64) {
+			if r.barrierEntry != nil {
+				r.barrierEntry.MarkNeedsBuild()
+			}
+		})
+	}
+
+	// Insert barrier first, then sheet (sheet on top)
+	r.overlayState.Insert(r.barrierEntry, nil, nil)
+	r.overlayState.Insert(r.sheetEntry, nil, r.barrierEntry) // above: barrierEntry
+}
+
+// onAnimationComplete is called when the sheet's dismiss animation finishes.
+// This removes the overlay entries and notifies the result callback.
+func (r *BottomSheetRoute) onAnimationComplete(result any) {
+	// Remove overlay entries
+	if r.barrierEntry != nil {
+		r.barrierEntry.Remove()
+		r.barrierEntry = nil
+	}
+	if r.sheetEntry != nil {
+		r.sheetEntry.Remove()
+		r.sheetEntry = nil
+	}
+	if r.progressRemove != nil {
+		r.progressRemove()
+		r.progressRemove = nil
+	}
+
+	// Notify dismiss callback (for ShowModalBottomSheet channel)
+	r.mu.Lock()
+	if !r.dismissed {
+		r.dismissed = true
+		onDismiss := r.onDismiss
+		r.mu.Unlock()
+		if onDismiss != nil {
+			onDismiss(result)
+		}
+	} else {
+		r.mu.Unlock()
+	}
+
+	// Pop from navigator if not already popped
+	// (This handles the case where dismiss was triggered by drag/barrier, not by Pop)
+	if !r.poppedFromNav {
+		if nav := r.navigator(); nav != nil {
+			nav.Pop(result)
+		}
+	}
+}
+
+func (r *BottomSheetRoute) navigator() NavigatorState {
+	if r.pushingNav != nil {
+		return r.pushingNav
+	}
+	// Access navigator through global scope - routes don't have direct access
+	return globalScope.ActiveNavigator()
+}
+
+// DidPop is called when the route is popped from the navigator.
+// This triggers the exit animation if not already animating.
+func (r *BottomSheetRoute) DidPop(result any) {
+	r.didPushPending = false
+	r.poppedFromNav = true
+
+	// Trigger exit animation via controller
+	// The animation will call onAnimationComplete when done
+	if r.controller != nil {
+		r.controller.Close(result)
+		return
+	}
+
+	// No controller (shouldn't happen), remove immediately
+	if r.barrierEntry != nil {
+		r.barrierEntry.Remove()
+		r.barrierEntry = nil
+	}
+	if r.sheetEntry != nil {
+		r.sheetEntry.Remove()
+		r.sheetEntry = nil
+	}
+	if r.progressRemove != nil {
+		r.progressRemove()
+		r.progressRemove = nil
+	}
+
+	// Notify dismiss callback
+	r.mu.Lock()
+	if !r.dismissed {
+		r.dismissed = true
+		onDismiss := r.onDismiss
+		r.mu.Unlock()
+		if onDismiss != nil {
+			onDismiss(result)
+		}
+	} else {
+		r.mu.Unlock()
+	}
+}
+
+// IsTransparent returns true - bottom sheets show content behind the barrier.
+func (r *BottomSheetRoute) IsTransparent() bool {
+	return true
+}
+
+// Build returns the widget for this route.
+// When overlay is available and entries inserted, returns a placeholder.
+func (r *BottomSheetRoute) Build(ctx core.BuildContext) core.Widget {
+	// When overlay is available and entries inserted, render placeholder
+	if r.overlayState != nil && r.barrierEntry != nil {
+		return widgets.SizedBox{} // Placeholder - content is in overlay
+	}
+	// Fallback: render directly (shouldn't happen in normal use)
+	if r.builder == nil {
+		return nil
+	}
+	return r.builder(ctx)
+}
+
+// BottomSheetOption configures a bottom sheet shown via ShowModalBottomSheet.
+type BottomSheetOption func(*BottomSheetRoute)
+
+// WithSnapPoints sets the snap points for the bottom sheet.
+func WithSnapPoints(points ...widgets.SnapPoint) BottomSheetOption {
+	return func(r *BottomSheetRoute) {
+		r.SnapPoints = points
+	}
+}
+
+// WithInitialSnapPoint sets the initial snap point index.
+func WithInitialSnapPoint(index int) BottomSheetOption {
+	return func(r *BottomSheetRoute) {
+		r.InitialSnapPoint = index
+	}
+}
+
+// WithBarrierDismissible sets whether tapping the barrier dismisses the sheet.
+func WithBarrierDismissible(dismissible bool) BottomSheetOption {
+	return func(r *BottomSheetRoute) {
+		r.BarrierDismissible = dismissible
+	}
+}
+
+// WithBarrierColor sets the barrier color.
+func WithBarrierColor(color graphics.Color) BottomSheetOption {
+	return func(r *BottomSheetRoute) {
+		r.BarrierColor = &color
+	}
+}
+
+// WithDragEnabled sets whether the sheet can be dragged.
+func WithDragEnabled(enabled bool) BottomSheetOption {
+	return func(r *BottomSheetRoute) {
+		r.EnableDrag = enabled
+	}
+}
+
+// WithDragMode sets how the sheet responds to drag gestures.
+func WithDragMode(mode widgets.DragMode) BottomSheetOption {
+	return func(r *BottomSheetRoute) {
+		r.DragMode = mode
+	}
+}
+
+// WithHandle sets whether a drag handle is shown.
+func WithHandle(show bool) BottomSheetOption {
+	return func(r *BottomSheetRoute) {
+		r.ShowHandle = show
+	}
+}
+
+// WithSafeArea sets whether the sheet respects the bottom safe area.
+func WithSafeArea(use bool) BottomSheetOption {
+	return func(r *BottomSheetRoute) {
+		r.UseSafeArea = use
+	}
+}
+
+// WithSnapBehavior customizes snap thresholds.
+func WithSnapBehavior(behavior widgets.SnapBehavior) BottomSheetOption {
+	return func(r *BottomSheetRoute) {
+		r.SnapBehavior = behavior
+	}
+}
+
+// ShowModalBottomSheet displays a modal bottom sheet.
+// Returns a buffered channel (size 1) that receives the result when dismissed.
+// The channel is closed after sending the result (or after close without result).
+// Callers can safely read once: result := <-ShowModalBottomSheet(...)
+//
+// To dismiss the sheet from content, use:
+//
+//	widgets.BottomSheetScope{}.Of(ctx).Close(result)
+//
+// Example:
+//
+//	result := <-navigation.ShowModalBottomSheet(ctx, func(ctx core.BuildContext) core.Widget {
+//	    return widgets.Column{
+//	        Children: []core.Widget{
+//	            widgets.Text{Content: "Select an option"},
+//	            widgets.Button{Label: "Option 1", OnTap: func() {
+//	                widgets.BottomSheetScope{}.Of(ctx).Close("option1")
+//	            }},
+//	        },
+//	    }
+//	}, navigation.WithSnapPoints(widgets.SnapHalf, widgets.SnapFull))
+func ShowModalBottomSheet(
+	ctx core.BuildContext,
+	builder func(ctx core.BuildContext) core.Widget,
+	options ...BottomSheetOption,
+) <-chan any {
+	result := make(chan any, 1) // Buffered to prevent blocking
+	var once sync.Once
+
+	route := NewBottomSheetRoute(builder, RouteSettings{})
+
+	// Apply options
+	for _, opt := range options {
+		opt(route)
+	}
+
+	// Set up dismiss callback
+	route.onDismiss = func(value any) {
+		// Idempotent: multiple dismiss paths (drag, barrier tap, back button)
+		// all call onDismiss, but we only send/close once
+		once.Do(func() {
+			result <- value
+			close(result)
+		})
+	}
+
+	// Push the route
+	nav := NavigatorOf(ctx)
+	if nav != nil {
+		route.pushingNav = nav
+		nav.Push(route)
+	} else {
+		once.Do(func() {
+			result <- nil
+			close(result)
+		})
+	}
+
+	return result
+}

--- a/pkg/navigation/bottom_sheet_route_test.go
+++ b/pkg/navigation/bottom_sheet_route_test.go
@@ -1,0 +1,326 @@
+package navigation
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/go-drift/drift/pkg/core"
+	"github.com/go-drift/drift/pkg/graphics"
+	"github.com/go-drift/drift/pkg/overlay"
+	"github.com/go-drift/drift/pkg/widgets"
+)
+
+type mockBuildContext struct{}
+
+func (m mockBuildContext) Widget() core.Widget                                   { return nil }
+func (m mockBuildContext) FindAncestor(func(core.Element) bool) core.Element     { return nil }
+func (m mockBuildContext) DependOnInherited(reflect.Type, any) any               { return nil }
+func (m mockBuildContext) DependOnInheritedWithAspects(reflect.Type, ...any) any { return nil }
+
+type fakeNavigator struct {
+	popCount int
+	lastPop  any
+}
+
+func (f *fakeNavigator) Push(Route)                       {}
+func (f *fakeNavigator) PushNamed(string, any)            {}
+func (f *fakeNavigator) PushReplacementNamed(string, any) {}
+func (f *fakeNavigator) Pop(result any)                   { f.popCount++; f.lastPop = result }
+func (f *fakeNavigator) PopUntil(func(Route) bool)        {}
+func (f *fakeNavigator) PushReplacement(Route)            {}
+func (f *fakeNavigator) CanPop() bool                     { return true }
+func (f *fakeNavigator) MaybePop(result any) bool         { f.Pop(result); return true }
+
+func TestNewBottomSheetRoute_Defaults(t *testing.T) {
+	route := NewBottomSheetRoute(nil, RouteSettings{})
+
+	if !route.BarrierDismissible {
+		t.Error("BarrierDismissible should default to true")
+	}
+	if !route.EnableDrag {
+		t.Error("EnableDrag should default to true")
+	}
+	if route.DragMode != widgets.DragModeAuto {
+		t.Error("DragMode should default to DragModeAuto")
+	}
+	if !route.ShowHandle {
+		t.Error("ShowHandle should default to true")
+	}
+	if !route.UseSafeArea {
+		t.Error("UseSafeArea should default to true")
+	}
+	if route.SnapPoints != nil {
+		t.Error("SnapPoints should default to nil (uses widget defaults)")
+	}
+	if route.InitialSnapPoint != 0 {
+		t.Error("InitialSnapPoint should default to 0")
+	}
+	if route.BarrierColor != nil {
+		t.Error("BarrierColor should default to nil (uses theme)")
+	}
+}
+
+func TestBottomSheetRoute_Options(t *testing.T) {
+	route := NewBottomSheetRoute(nil, RouteSettings{})
+
+	// Apply options
+	WithSnapPoints(widgets.SnapHalf, widgets.SnapFull)(route)
+	WithInitialSnapPoint(1)(route)
+	WithBarrierDismissible(false)(route)
+	WithBarrierColor(graphics.ColorBlack)(route)
+	WithDragEnabled(false)(route)
+	WithDragMode(widgets.DragModeHandleOnly)(route)
+	WithHandle(false)(route)
+	WithSafeArea(false)(route)
+
+	if len(route.SnapPoints) != 2 {
+		t.Errorf("Expected 2 snap points, got %d", len(route.SnapPoints))
+	}
+	if route.InitialSnapPoint != 1 {
+		t.Errorf("Expected InitialSnapPoint 1, got %d", route.InitialSnapPoint)
+	}
+	if route.BarrierDismissible {
+		t.Error("Expected BarrierDismissible false")
+	}
+	if route.BarrierColor == nil || *route.BarrierColor != graphics.ColorBlack {
+		t.Error("Expected BarrierColor to be ColorBlack")
+	}
+	if route.EnableDrag {
+		t.Error("Expected EnableDrag false")
+	}
+	if route.DragMode != widgets.DragModeHandleOnly {
+		t.Error("Expected DragModeHandleOnly")
+	}
+	if route.ShowHandle {
+		t.Error("Expected ShowHandle false")
+	}
+	if route.UseSafeArea {
+		t.Error("Expected UseSafeArea false")
+	}
+}
+
+func TestBottomSheetRoute_DidPush_PendingWithoutOverlay(t *testing.T) {
+	route := NewBottomSheetRoute(nil, RouteSettings{})
+
+	// Simulate DidPush before overlay is ready
+	route.DidPush()
+	if !route.didPushPending {
+		t.Error("didPushPending should be true when DidPush called without overlay")
+	}
+}
+
+func TestBottomSheetRoute_DidPop_ClearsState(t *testing.T) {
+	route := NewBottomSheetRoute(nil, RouteSettings{})
+	route.didPushPending = true
+
+	route.DidPop(nil)
+
+	if route.didPushPending {
+		t.Error("didPushPending should be false after DidPop")
+	}
+	if route.barrierEntry != nil {
+		t.Error("barrierEntry should be nil after DidPop")
+	}
+	if route.sheetEntry != nil {
+		t.Error("sheetEntry should be nil after DidPop")
+	}
+}
+
+func TestBottomSheetRoute_DidPop_RemovesEntries(t *testing.T) {
+	route := NewBottomSheetRoute(nil, RouteSettings{})
+
+	// Create actual overlay entries
+	barrierRemoved := false
+	sheetRemoved := false
+
+	route.barrierEntry = overlay.NewOverlayEntry(nil)
+	route.sheetEntry = overlay.NewOverlayEntry(nil)
+
+	// Track if entries are cleared (real Remove needs overlay, so we just check nil)
+	route.DidPop("test-result")
+
+	// Entries should be nil after DidPop (even if Remove() didn't work due to no overlay)
+	if route.barrierEntry != nil {
+		t.Error("barrierEntry should be nil after DidPop")
+	}
+	if route.sheetEntry != nil {
+		t.Error("sheetEntry should be nil after DidPop")
+	}
+
+	// These are checked just to avoid unused variable warnings
+	_ = barrierRemoved
+	_ = sheetRemoved
+}
+
+func TestBottomSheetRoute_DismissIdempotent(t *testing.T) {
+	route := NewBottomSheetRoute(nil, RouteSettings{})
+
+	dismissCount := 0
+	route.onDismiss = func(any) {
+		dismissCount++
+	}
+
+	// First dismiss via onAnimationComplete should call onDismiss
+	route.onAnimationComplete("result1")
+	if dismissCount != 1 {
+		t.Errorf("Expected 1 dismiss call, got %d", dismissCount)
+	}
+
+	// Second dismiss should be ignored (idempotent)
+	route.onAnimationComplete("result2")
+	if dismissCount != 1 {
+		t.Errorf("Expected still 1 dismiss call (idempotent), got %d", dismissCount)
+	}
+}
+
+func TestBottomSheetRoute_DismissCallsOnDismiss(t *testing.T) {
+	route := NewBottomSheetRoute(nil, RouteSettings{})
+
+	var receivedResult any
+	route.onDismiss = func(result any) {
+		receivedResult = result
+	}
+
+	// Simulate animation completion calling onAnimationComplete
+	route.onAnimationComplete("test-result")
+
+	if receivedResult != "test-result" {
+		t.Errorf("Expected 'test-result', got %v", receivedResult)
+	}
+}
+
+func TestShowModalBottomSheet_ChannelReceivesResult(t *testing.T) {
+	// This test verifies the channel behavior without a real navigator
+	route := NewBottomSheetRoute(nil, RouteSettings{})
+
+	resultChan := make(chan any, 1)
+	route.onDismiss = func(value any) {
+		resultChan <- value
+		close(resultChan)
+	}
+
+	// Simulate animation completing with result
+	route.onAnimationComplete("test-result")
+
+	// Channel should receive the result
+	select {
+	case result := <-resultChan:
+		if result != "test-result" {
+			t.Errorf("Expected result 'test-result', got %v", result)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("Timeout waiting for result")
+	}
+
+	// Channel should be closed (reading again should return default value)
+	select {
+	case _, ok := <-resultChan:
+		if ok {
+			t.Error("Expected channel to be closed")
+		}
+	default:
+		// Channel is closed and empty - this is expected
+	}
+}
+
+func TestShowModalBottomSheet_ChannelWorksWithNilResult(t *testing.T) {
+	route := NewBottomSheetRoute(nil, RouteSettings{})
+
+	resultChan := make(chan any, 1)
+	route.onDismiss = func(value any) {
+		resultChan <- value
+		close(resultChan)
+	}
+
+	// Simulate animation completing without result
+	route.onAnimationComplete(nil)
+
+	// Channel should receive nil
+	select {
+	case result := <-resultChan:
+		if result != nil {
+			t.Errorf("Expected nil result, got %v", result)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("Timeout waiting for result")
+	}
+}
+
+func TestBottomSheetRoute_DidPop_CallsOnDismiss(t *testing.T) {
+	route := NewBottomSheetRoute(nil, RouteSettings{})
+
+	var onDismissCalled bool
+	var receivedResult any
+	route.onDismiss = func(result any) {
+		onDismissCalled = true
+		receivedResult = result
+	}
+
+	// DidPop should call onDismiss if not already dismissed
+	route.DidPop("pop-result")
+
+	if !onDismissCalled {
+		t.Error("onDismiss should be called from DidPop")
+	}
+	if receivedResult != "pop-result" {
+		t.Errorf("Expected 'pop-result', got %v", receivedResult)
+	}
+}
+
+func TestBottomSheetRoute_DidPop_IdempotentWithDismiss(t *testing.T) {
+	route := NewBottomSheetRoute(nil, RouteSettings{})
+
+	dismissCount := 0
+	route.onDismiss = func(any) {
+		dismissCount++
+	}
+
+	// First dismiss via onAnimationComplete (simulating animation finished)
+	route.onAnimationComplete("dismiss-result")
+	if dismissCount != 1 {
+		t.Fatalf("Expected 1 dismiss call after onAnimationComplete(), got %d", dismissCount)
+	}
+
+	// DidPop should not call onDismiss again (already dismissed)
+	route.DidPop("pop-result")
+	if dismissCount != 1 {
+		t.Errorf("Expected still 1 dismiss call after DidPop (already dismissed), got %d", dismissCount)
+	}
+}
+
+func TestBottomSheetRoute_OnAnimationComplete_DoesNotPopWhenDidPop(t *testing.T) {
+	route := NewBottomSheetRoute(nil, RouteSettings{})
+	nav := &fakeNavigator{}
+	route.pushingNav = nav
+	route.poppedFromNav = true
+
+	route.onAnimationComplete("result")
+
+	if nav.popCount != 0 {
+		t.Errorf("Expected Pop not to be called, got %d", nav.popCount)
+	}
+}
+
+func TestShowModalBottomSheet_NavigatorNilClosesChannel(t *testing.T) {
+	ctx := mockBuildContext{}
+	ch := ShowModalBottomSheet(ctx, func(core.BuildContext) core.Widget {
+		return nil
+	})
+
+	select {
+	case result, ok := <-ch:
+		if !ok {
+			t.Fatal("Expected channel to yield a value before closing")
+		}
+		if result != nil {
+			t.Errorf("Expected nil result, got %v", result)
+		}
+		_, ok = <-ch
+		if ok {
+			t.Error("Expected channel to be closed")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Timed out waiting for channel result")
+	}
+}

--- a/pkg/navigation/modal_route.go
+++ b/pkg/navigation/modal_route.go
@@ -109,6 +109,11 @@ func (r *ModalRoute) DidPop(result any) {
 	}
 }
 
+// IsTransparent returns true - modals show content behind the barrier.
+func (r *ModalRoute) IsTransparent() bool {
+	return true
+}
+
 // Build returns the widget for this route.
 // When overlay is available and entries inserted, returns a placeholder.
 // Falls back to direct rendering if no overlay is available.

--- a/pkg/navigation/route.go
+++ b/pkg/navigation/route.go
@@ -154,6 +154,15 @@ type Route interface {
 	SetOverlay(overlay OverlayState)
 }
 
+// TransparentRoute is implemented by routes that should keep previous routes visible.
+// Routes like bottom sheets and dialogs that have semi-transparent barriers
+// should implement this and return true from IsTransparent.
+type TransparentRoute interface {
+	Route
+	// IsTransparent returns true if previous routes should remain visible.
+	IsTransparent() bool
+}
+
 // BaseRoute provides a default implementation of Route lifecycle methods.
 type BaseRoute struct {
 	settings RouteSettings

--- a/pkg/overlay/overlay_test.go
+++ b/pkg/overlay/overlay_test.go
@@ -829,8 +829,8 @@ func TestRenderOverlay_HitTest_NoOpaquePassesToChild(t *testing.T) {
 // are hit tested even when an opaque entry exists (allows barriers to receive hits).
 func TestRenderOverlay_HitTest_AllEntriesTested(t *testing.T) {
 	child := newTestHitRenderBox(400, 400, true)
-	barrier := newTestHitRenderBox(400, 400, true)  // Full-screen barrier below dialog
-	dialog := newTestHitRenderBox(200, 200, false)  // Dialog doesn't accept hit at test position
+	barrier := newTestHitRenderBox(400, 400, true) // Full-screen barrier below dialog
+	dialog := newTestHitRenderBox(200, 200, false) // Dialog doesn't accept hit at test position
 
 	r := &renderOverlay{
 		opaqueIndex: 1, // Dialog is opaque (second entry)

--- a/pkg/theme/component_themes.go
+++ b/pkg/theme/component_themes.go
@@ -248,3 +248,37 @@ func DefaultDropdownTheme(colors ColorScheme) DropdownThemeData {
 		FontSize:            16,
 	}
 }
+
+// BottomSheetThemeData defines default styling for BottomSheet widgets.
+type BottomSheetThemeData struct {
+	// BackgroundColor is the sheet's background color.
+	BackgroundColor graphics.Color
+	// HandleColor is the drag handle indicator color.
+	HandleColor graphics.Color
+	// BarrierColor is the color of the semi-transparent barrier behind the sheet.
+	BarrierColor graphics.Color
+	// BorderRadius is the corner radius for the top corners of the sheet.
+	BorderRadius float64
+	// HandleWidth is the width of the drag handle indicator.
+	HandleWidth float64
+	// HandleHeight is the height of the drag handle indicator.
+	HandleHeight float64
+	// HandleTopPadding is the padding above the drag handle.
+	HandleTopPadding float64
+	// HandleBottomPadding is the padding below the drag handle.
+	HandleBottomPadding float64
+}
+
+// DefaultBottomSheetTheme returns BottomSheetThemeData derived from a ColorScheme.
+func DefaultBottomSheetTheme(colors ColorScheme) BottomSheetThemeData {
+	return BottomSheetThemeData{
+		BackgroundColor:     colors.Surface,
+		HandleColor:         colors.OnSurfaceVariant,
+		BarrierColor:        graphics.RGBA(0, 0, 0, 0.5),
+		BorderRadius:        16,
+		HandleWidth:         32,
+		HandleHeight:        4,
+		HandleTopPadding:    8,
+		HandleBottomPadding: 8,
+	}
+}

--- a/pkg/theme/theme_data.go
+++ b/pkg/theme/theme_data.go
@@ -12,13 +12,14 @@ type ThemeData struct {
 	Brightness Brightness
 
 	// Component themes - optional, derived from ColorScheme if nil.
-	ButtonTheme    *ButtonThemeData
-	CheckboxTheme  *CheckboxThemeData
-	SwitchTheme    *SwitchThemeData
-	TextFieldTheme *TextFieldThemeData
-	TabBarTheme    *TabBarThemeData
-	RadioTheme     *RadioThemeData
-	DropdownTheme  *DropdownThemeData
+	ButtonTheme      *ButtonThemeData
+	CheckboxTheme    *CheckboxThemeData
+	SwitchTheme      *SwitchThemeData
+	TextFieldTheme   *TextFieldThemeData
+	TabBarTheme      *TabBarThemeData
+	RadioTheme       *RadioThemeData
+	DropdownTheme    *DropdownThemeData
+	BottomSheetTheme *BottomSheetThemeData
 }
 
 // DefaultLightTheme returns the default light theme.
@@ -44,16 +45,17 @@ func DefaultDarkTheme() *ThemeData {
 // CopyWith returns a new ThemeData with the specified fields overridden.
 func (t *ThemeData) CopyWith(colorScheme *ColorScheme, textTheme *TextTheme, brightness *Brightness) *ThemeData {
 	result := &ThemeData{
-		ColorScheme:    t.ColorScheme,
-		TextTheme:      t.TextTheme,
-		Brightness:     t.Brightness,
-		ButtonTheme:    t.ButtonTheme,
-		CheckboxTheme:  t.CheckboxTheme,
-		SwitchTheme:    t.SwitchTheme,
-		TextFieldTheme: t.TextFieldTheme,
-		TabBarTheme:    t.TabBarTheme,
-		RadioTheme:     t.RadioTheme,
-		DropdownTheme:  t.DropdownTheme,
+		ColorScheme:      t.ColorScheme,
+		TextTheme:        t.TextTheme,
+		Brightness:       t.Brightness,
+		ButtonTheme:      t.ButtonTheme,
+		CheckboxTheme:    t.CheckboxTheme,
+		SwitchTheme:      t.SwitchTheme,
+		TextFieldTheme:   t.TextFieldTheme,
+		TabBarTheme:      t.TabBarTheme,
+		RadioTheme:       t.RadioTheme,
+		DropdownTheme:    t.DropdownTheme,
+		BottomSheetTheme: t.BottomSheetTheme,
 	}
 	if colorScheme != nil {
 		result.ColorScheme = *colorScheme
@@ -121,4 +123,12 @@ func (t *ThemeData) DropdownThemeOf() DropdownThemeData {
 		return *t.DropdownTheme
 	}
 	return DefaultDropdownTheme(t.ColorScheme)
+}
+
+// BottomSheetThemeOf returns the bottom sheet theme, deriving from ColorScheme if not set.
+func (t *ThemeData) BottomSheetThemeOf() BottomSheetThemeData {
+	if t.BottomSheetTheme != nil {
+		return *t.BottomSheetTheme
+	}
+	return DefaultBottomSheetTheme(t.ColorScheme)
 }

--- a/pkg/widgets/bottom_sheet.go
+++ b/pkg/widgets/bottom_sheet.go
@@ -1,0 +1,1134 @@
+package widgets
+
+import (
+	"math"
+	"reflect"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/go-drift/drift/pkg/animation"
+	"github.com/go-drift/drift/pkg/core"
+	"github.com/go-drift/drift/pkg/graphics"
+	"github.com/go-drift/drift/pkg/layout"
+)
+
+// SnapPoint defines a height position where a bottom sheet can snap.
+// FractionalHeight is relative to available height (screen height minus safe area insets).
+type SnapPoint struct {
+	FractionalHeight float64
+	Name             string
+}
+
+// Common snap point presets.
+var (
+	SnapThird = SnapPoint{FractionalHeight: 0.33, Name: "third"}
+	SnapHalf  = SnapPoint{FractionalHeight: 0.5, Name: "half"}
+	SnapFull  = SnapPoint{FractionalHeight: 1.0, Name: "full"}
+)
+
+// DefaultSnapPoints is used when no snap points are provided.
+var DefaultSnapPoints = []SnapPoint{SnapFull}
+
+// NormalizeSnapPoints validates and normalizes snap points.
+// It clamps values to [0.1, 1.0], sorts ascending, and removes duplicates.
+func NormalizeSnapPoints(points []SnapPoint) []SnapPoint {
+	if len(points) == 0 {
+		return DefaultSnapPoints
+	}
+	result := make([]SnapPoint, 0, len(points))
+	for _, p := range points {
+		p.FractionalHeight = clampFloat(p.FractionalHeight, 0.1, 1.0)
+		result = append(result, p)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].FractionalHeight < result[j].FractionalHeight
+	})
+	return dedupByHeight(result)
+}
+
+// dedupByHeight removes snap points with duplicate fractional heights,
+// keeping only the first occurrence of each height.
+func dedupByHeight(points []SnapPoint) []SnapPoint {
+	if len(points) == 0 {
+		return points
+	}
+	seen := make(map[float64]bool)
+	result := make([]SnapPoint, 0, len(points))
+	for _, p := range points {
+		if !seen[p.FractionalHeight] {
+			seen[p.FractionalHeight] = true
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+// ValidateInitialSnap ensures the initial snap index is valid.
+func ValidateInitialSnap(index int, points []SnapPoint) int {
+	if index < 0 || index >= len(points) {
+		return 0
+	}
+	return index
+}
+
+// clampFloat constrains v to the range [min, max].
+func clampFloat(v, min, max float64) float64 {
+	if v < min {
+		return min
+	}
+	if v > max {
+		return max
+	}
+	return v
+}
+
+// DragMode controls how drag gestures interact with bottom sheet content.
+type DragMode int
+
+const (
+	// DragModeAuto picks DragModeContentAware for multi-snap sheets and DragModeSheet otherwise.
+	DragModeAuto DragMode = iota
+	// DragModeContentAware coordinates drags with scrollable content when possible.
+	DragModeContentAware
+	// DragModeSheet drags the entire sheet regardless of content.
+	DragModeSheet
+	// DragModeHandleOnly only accepts drags from the handle area.
+	DragModeHandleOnly
+)
+
+// SnapBehavior configures snapping and dismissal thresholds.
+type SnapBehavior struct {
+	// DismissFactor is the fraction of the minimum snap height below which a drag-down can dismiss.
+	DismissFactor float64
+	// MinFlingVelocity is the velocity (px/s) that triggers fast dismiss when dragging downward.
+	MinFlingVelocity float64
+	// SnapVelocityThreshold is the velocity (px/s) above which we snap in the direction of travel.
+	SnapVelocityThreshold float64
+}
+
+// DefaultSnapBehavior returns recommended defaults.
+func DefaultSnapBehavior() SnapBehavior {
+	return SnapBehavior{
+		DismissFactor:         0.5,
+		MinFlingVelocity:      1200,
+		SnapVelocityThreshold: 400,
+	}
+}
+
+// normalizeSnapBehavior fills in zero values with defaults.
+func normalizeSnapBehavior(value SnapBehavior) SnapBehavior {
+	defaults := DefaultSnapBehavior()
+	if value.DismissFactor <= 0 {
+		value.DismissFactor = defaults.DismissFactor
+	}
+	if value.MinFlingVelocity <= 0 {
+		value.MinFlingVelocity = defaults.MinFlingVelocity
+	}
+	if value.SnapVelocityThreshold <= 0 {
+		value.SnapVelocityThreshold = defaults.SnapVelocityThreshold
+	}
+	return value
+}
+
+// BottomSheetController controls a bottom sheet's behavior.
+// Create with NewBottomSheetController and pass to BottomSheet widget.
+// Content inside the sheet can access the controller via BottomSheetScope.Of(ctx).
+type BottomSheetController struct {
+	mu sync.Mutex
+
+	dismissFunc        func(any)
+	snapToIndexFunc    func(int)
+	snapToFractionFunc func(float64)
+	extentFunc         func() float64
+	registerScrollable func(*ScrollController) func()
+
+	dismissCalled bool
+	pendingResult any
+
+	progress     float64
+	listeners    map[int]func(float64)
+	nextListener int
+}
+
+// NewBottomSheetController creates a new controller for a bottom sheet.
+func NewBottomSheetController() *BottomSheetController {
+	return &BottomSheetController{}
+}
+
+// Close triggers the sheet's dismiss animation with the given result.
+// The result will be passed to OnDismiss when animation completes.
+// Safe to call multiple times - only the first call has effect.
+func (c *BottomSheetController) Close(result any) {
+	c.mu.Lock()
+	if c.dismissCalled {
+		c.mu.Unlock()
+		return
+	}
+	c.dismissCalled = true
+	dismissFunc := c.dismissFunc
+	c.pendingResult = result
+	c.mu.Unlock()
+
+	if dismissFunc != nil {
+		dismissFunc(result)
+	}
+}
+
+// SnapTo animates the sheet to the snap point at the given index.
+func (c *BottomSheetController) SnapTo(index int) {
+	c.mu.Lock()
+	snapFunc := c.snapToIndexFunc
+	c.mu.Unlock()
+	if snapFunc != nil {
+		snapFunc(index)
+	}
+}
+
+// SnapToFraction animates the sheet to a fractional snap point.
+// The value is clamped to [0, 1].
+func (c *BottomSheetController) SnapToFraction(fraction float64) {
+	c.mu.Lock()
+	snapFunc := c.snapToFractionFunc
+	c.mu.Unlock()
+	if snapFunc != nil {
+		snapFunc(fraction)
+	}
+}
+
+// Extent returns the current sheet extent in pixels.
+func (c *BottomSheetController) Extent() float64 {
+	c.mu.Lock()
+	extentFunc := c.extentFunc
+	c.mu.Unlock()
+	if extentFunc == nil {
+		return 0
+	}
+	return extentFunc()
+}
+
+// Progress returns the current open progress from 0.0 to 1.0.
+func (c *BottomSheetController) Progress() float64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.progress
+}
+
+// AddProgressListener registers a callback for progress changes.
+func (c *BottomSheetController) AddProgressListener(listener func(float64)) func() {
+	if listener == nil {
+		return func() {}
+	}
+	c.mu.Lock()
+	if c.listeners == nil {
+		c.listeners = make(map[int]func(float64))
+	}
+	id := c.nextListener
+	c.nextListener++
+	c.listeners[id] = listener
+	c.mu.Unlock()
+	return func() {
+		c.mu.Lock()
+		delete(c.listeners, id)
+		c.mu.Unlock()
+	}
+}
+
+// attach binds the controller to a bottom sheet's state callbacks.
+// Called by bottomSheetState when initializing or when the controller changes.
+// If Close was called before attach, the pending dismiss is executed immediately.
+func (c *BottomSheetController) attach(
+	dismiss func(any),
+	snapToIndex func(int),
+	snapToFraction func(float64),
+	extent func() float64,
+	registerScrollable func(*ScrollController) func(),
+) {
+	c.mu.Lock()
+	c.dismissFunc = dismiss
+	c.snapToIndexFunc = snapToIndex
+	c.snapToFractionFunc = snapToFraction
+	c.extentFunc = extent
+	c.registerScrollable = registerScrollable
+	dismissCalled := c.dismissCalled
+	pending := c.pendingResult
+	c.mu.Unlock()
+
+	// Handle early-dismiss: Close() was called before the sheet was ready
+	if dismissCalled && dismiss != nil {
+		dismiss(pending)
+	}
+}
+
+// detach unbinds the controller from the sheet's state callbacks.
+// Called when the sheet is disposed or the controller is replaced.
+func (c *BottomSheetController) detach() {
+	c.mu.Lock()
+	c.dismissFunc = nil
+	c.snapToIndexFunc = nil
+	c.snapToFractionFunc = nil
+	c.extentFunc = nil
+	c.registerScrollable = nil
+	c.mu.Unlock()
+}
+
+// setProgress updates the open progress and notifies all listeners.
+// Called by the sheet state during animations and drag updates.
+func (c *BottomSheetController) setProgress(value float64) {
+	value = clampFloat(value, 0, 1)
+	c.mu.Lock()
+	if c.progress == value {
+		c.mu.Unlock()
+		return
+	}
+	c.progress = value
+	// Copy listeners to avoid holding lock during callbacks
+	listeners := make([]func(float64), 0, len(c.listeners))
+	for _, listener := range c.listeners {
+		listeners = append(listeners, listener)
+	}
+	c.mu.Unlock()
+	for _, listener := range listeners {
+		listener(value)
+	}
+}
+
+func (c *BottomSheetController) registerScrollableInternal(controller *ScrollController) func() {
+	c.mu.Lock()
+	register := c.registerScrollable
+	c.mu.Unlock()
+	if register == nil || controller == nil {
+		return func() {}
+	}
+	return register(controller)
+}
+
+// BottomSheetTheme holds theming data for a bottom sheet.
+// This is passed from the route which has access to the theme system.
+type BottomSheetTheme struct {
+	BackgroundColor     graphics.Color
+	HandleColor         graphics.Color
+	BorderRadius        float64
+	HandleWidth         float64
+	HandleHeight        float64
+	HandleTopPadding    float64
+	HandleBottomPadding float64
+}
+
+// DefaultBottomSheetTheme returns default theme values.
+func DefaultBottomSheetTheme() BottomSheetTheme {
+	return BottomSheetTheme{
+		BackgroundColor:     graphics.ColorWhite,
+		HandleColor:         graphics.RGBA(200, 200, 200, 255),
+		BorderRadius:        16,
+		HandleWidth:         32,
+		HandleHeight:        4,
+		HandleTopPadding:    8,
+		HandleBottomPadding: 8,
+	}
+}
+
+// BottomSheet is the widget for rendering a bottom sheet with animations and gestures.
+// Use BottomSheetController to programmatically dismiss or snap the sheet.
+type BottomSheet struct {
+	// Builder creates the sheet content.
+	Builder func(ctx core.BuildContext) core.Widget
+	// Controller allows programmatic control of the sheet.
+	Controller *BottomSheetController
+	// SnapPoints defines the snap positions as fractions of available height.
+	// When empty, the sheet sizes to content height.
+	SnapPoints []SnapPoint
+	// InitialSnap is the index into SnapPoints to open at.
+	InitialSnap int
+
+	// EnableDrag toggles drag gestures for the sheet.
+	EnableDrag bool
+	// DragMode defines how drag gestures interact with content.
+	DragMode DragMode
+	// ShowHandle displays the drag handle at the top of the sheet.
+	ShowHandle bool
+	// UseSafeArea applies safe area insets to the sheet layout.
+	UseSafeArea bool
+
+	// Theme configures the sheet's visual styling.
+	Theme BottomSheetTheme
+	// SnapBehavior customizes snapping and dismiss thresholds.
+	SnapBehavior SnapBehavior
+	// OnDismiss fires after the sheet finishes its dismiss animation.
+	OnDismiss func(result any)
+}
+
+func (b BottomSheet) CreateElement() core.Element {
+	return core.NewStatefulElement(b, nil)
+}
+
+func (b BottomSheet) Key() any {
+	return nil
+}
+
+func (b BottomSheet) CreateState() core.State {
+	return &bottomSheetState{}
+}
+
+// bottomSheetState manages the runtime state for a BottomSheet widget.
+// It handles animations, drag gestures, snap point calculations, and
+// coordinates with scrollable content for content-aware dragging.
+type bottomSheetState struct {
+	core.StateBase
+
+	// Configuration from widget
+	snapPoints   []SnapPoint // normalized snap points (sorted, deduped)
+	snapHeights  []float64   // snap points converted to pixel heights
+	initialIndex int         // which snap point to open at
+	contentSized bool        // true if sheet sizes to content (no snap points provided)
+
+	enableDrag  bool
+	dragMode    DragMode
+	showHandle  bool
+	useSafeArea bool
+
+	theme        BottomSheetTheme
+	snapBehavior SnapBehavior
+	onDismiss    func(any)
+	controller   *BottomSheetController
+	builder      func(core.BuildContext) core.Widget
+
+	// Layout metrics from positioner callback
+	metricsReady    bool    // true after first layout pass
+	availableHeight float64 // screen height minus safe area insets
+	screenHeight    float64
+	topInset        float64
+	bottomInset     float64
+
+	// Animation state
+	currentExtent float64 // current sheet height in pixels (animated)
+	targetExtent  float64 // target sheet height for animations
+	isDragging    bool    // true while user is actively dragging
+	isDismissing  bool    // true while dismiss animation is running
+
+	spring *animation.SpringSimulation // physics simulation for snapping
+	ticker *animation.Ticker           // drives animation frames
+
+	// Content-aware drag coordination
+	scrollController *ScrollController // registered scrollable's controller
+	scrollOffset     float64           // current scroll position (for drag decisions)
+	scrollRemove     func()            // cleanup function for scroll listener
+}
+
+func (s *bottomSheetState) InitState() {
+	w := s.Element().Widget().(BottomSheet)
+	s.applyWidget(w)
+
+	if s.controller != nil {
+		s.controller.attach(
+			s.requestDismiss,
+			s.snapToIndex,
+			s.snapToFraction,
+			s.currentExtentPx,
+			s.registerScrollable,
+		)
+	}
+}
+
+func (s *bottomSheetState) DidUpdateWidget(oldWidget core.StatefulWidget) {
+	w := s.Element().Widget().(BottomSheet)
+	old := oldWidget.(BottomSheet)
+	s.applyWidget(w)
+
+	if w.Controller != old.Controller {
+		if old.Controller != nil {
+			old.Controller.detach()
+		}
+		if s.controller != nil {
+			s.controller.attach(
+				s.requestDismiss,
+				s.snapToIndex,
+				s.snapToFraction,
+				s.currentExtentPx,
+				s.registerScrollable,
+			)
+		}
+	}
+}
+
+func (s *bottomSheetState) applyWidget(w BottomSheet) {
+	s.contentSized = len(w.SnapPoints) == 0
+	if s.contentSized {
+		s.snapPoints = nil
+		s.initialIndex = 0
+	} else {
+		s.snapPoints = NormalizeSnapPoints(w.SnapPoints)
+		s.initialIndex = ValidateInitialSnap(w.InitialSnap, s.snapPoints)
+	}
+
+	s.enableDrag = w.EnableDrag
+	s.dragMode = w.DragMode
+	s.showHandle = w.ShowHandle
+	s.useSafeArea = w.UseSafeArea
+	s.theme = w.Theme
+	s.snapBehavior = normalizeSnapBehavior(w.SnapBehavior)
+	s.onDismiss = w.OnDismiss
+	s.controller = w.Controller
+	s.builder = w.Builder
+}
+
+func (s *bottomSheetState) Dispose() {
+	if s.controller != nil {
+		s.controller.detach()
+	}
+	if s.ticker != nil {
+		s.ticker.Stop()
+	}
+	if s.scrollRemove != nil {
+		s.scrollRemove()
+		s.scrollRemove = nil
+	}
+}
+
+func (s *bottomSheetState) Build(ctx core.BuildContext) core.Widget {
+	var content core.Widget
+	if s.controller != nil {
+		content = bottomSheetScopeBuilder{
+			controller: s.controller,
+			builder:    s.builder,
+		}
+	} else if s.builder != nil {
+		content = s.builder(ctx)
+	}
+
+	var handleWidget core.Widget = SizedBox{}
+	if s.showHandle {
+		handleWidget = s.buildHandle()
+	}
+
+	dragMode := s.resolveDragMode()
+	if s.enableDrag && dragMode == DragModeHandleOnly && s.showHandle {
+		handleWidget = sheetDragRegion{
+			Child:       handleWidget,
+			ShouldStart: s.shouldStartHandleDrag,
+			OnStart:     s.onDragStart,
+			OnUpdate:    s.onDragUpdate,
+			OnEnd:       s.onDragEnd,
+		}
+	}
+
+	var topInset, bottomInset float64
+	if s.useSafeArea {
+		topInset = SafeAreaTopOf(ctx)
+		bottomInset = SafeAreaBottomOf(ctx)
+	}
+
+	body := bottomSheetBody{
+		Handle:       handleWidget,
+		Content:      content,
+		BottomInset:  bottomInset,
+		Background:   s.theme.BackgroundColor,
+		BorderRadius: s.theme.BorderRadius,
+		ContentSized: s.contentSized,
+	}
+
+	var sheet core.Widget = body
+	if s.enableDrag && dragMode != DragModeHandleOnly {
+		sheet = sheetDragRegion{
+			Child:       body,
+			ShouldStart: s.shouldStartDrag,
+			OnStart:     s.onDragStart,
+			OnUpdate:    s.onDragUpdate,
+			OnEnd:       s.onDragEnd,
+		}
+	}
+
+	return bottomSheetPositioner{
+		Extent:       s.currentExtent,
+		TopInset:     topInset,
+		BottomInset:  bottomInset,
+		ContentSized: s.contentSized,
+		Child:        sheet,
+		OnMetrics:    s.onMetrics,
+	}
+}
+
+// resolveDragMode converts DragModeAuto to a concrete mode based on configuration.
+// Multi-snap sheets default to content-aware dragging; single-snap sheets default to sheet dragging.
+func (s *bottomSheetState) resolveDragMode() DragMode {
+	if s.dragMode == DragModeAuto {
+		if len(s.snapPoints) > 1 {
+			return DragModeContentAware
+		}
+		return DragModeSheet
+	}
+	return s.dragMode
+}
+
+// onMetrics is called by the positioner after layout with current screen dimensions.
+// It converts fractional snap points to pixel heights and triggers the opening animation
+// on first layout, or rescales extents when the available height changes (e.g., rotation).
+func (s *bottomSheetState) onMetrics(metrics sheetMetrics) {
+	if metrics.AvailableHeight <= 0 {
+		return
+	}
+
+	prevAvailable := s.availableHeight
+	s.metricsReady = true
+	s.availableHeight = metrics.AvailableHeight
+	s.screenHeight = metrics.ScreenHeight
+	s.topInset = metrics.TopInset
+	s.bottomInset = metrics.BottomInset
+
+	// Content-sized sheets: derive snap height from actual content size
+	if s.contentSized {
+		if metrics.ContentHeight > 0 {
+			contentExtent := clampFloat(metrics.ContentHeight, 0, s.availableHeight)
+			if len(s.snapHeights) == 0 || s.snapHeights[0] != contentExtent {
+				s.snapHeights = []float64{contentExtent}
+			}
+			// First layout or no target yet: start opening animation
+			if prevAvailable <= 0 || s.targetExtent == 0 {
+				s.currentExtent = 0
+				s.targetExtent = contentExtent
+				s.animateTo(s.targetExtent, 0)
+			} else if s.targetExtent != contentExtent {
+				// Content size changed: update target, clamp current
+				s.targetExtent = contentExtent
+				if s.currentExtent > contentExtent {
+					s.currentExtent = contentExtent
+				}
+			}
+		}
+		s.updateProgress()
+		return
+	}
+
+	// Convert fractional snap points to pixel heights
+	s.snapHeights = make([]float64, len(s.snapPoints))
+	for i, snap := range s.snapPoints {
+		s.snapHeights[i] = snap.FractionalHeight * s.availableHeight
+	}
+	if len(s.snapHeights) == 0 {
+		return
+	}
+
+	// First layout: start opening animation to initial snap point
+	if prevAvailable <= 0 {
+		s.currentExtent = 0
+		s.targetExtent = s.snapHeights[s.initialIndex]
+		s.animateTo(s.targetExtent, 0)
+		return
+	}
+
+	// Available height changed (rotation, keyboard): scale extents proportionally
+	if prevAvailable != s.availableHeight {
+		ratio := s.availableHeight / prevAvailable
+		s.currentExtent = clampFloat(s.currentExtent*ratio, 0, s.availableHeight)
+		s.targetExtent = clampFloat(s.targetExtent*ratio, 0, s.availableHeight)
+	}
+	s.updateProgress()
+}
+
+func (s *bottomSheetState) currentExtentPx() float64 {
+	return s.currentExtent
+}
+
+func (s *bottomSheetState) requestDismiss(result any) {
+	if s.isDismissing {
+		return
+	}
+	s.isDismissing = true
+	s.animateToDismiss(result)
+}
+
+func (s *bottomSheetState) snapToIndex(index int) {
+	if !s.metricsReady || len(s.snapHeights) == 0 {
+		return
+	}
+	if index < 0 || index >= len(s.snapHeights) {
+		index = 0
+	}
+	s.animateTo(s.snapHeights[index], 0)
+}
+
+func (s *bottomSheetState) snapToFraction(fraction float64) {
+	if !s.metricsReady {
+		return
+	}
+	fraction = clampFloat(fraction, 0, 1)
+	s.animateTo(fraction*s.availableHeight, 0)
+}
+
+func (s *bottomSheetState) animateTo(target, velocity float64) {
+	if !s.metricsReady {
+		return
+	}
+	if s.ticker != nil {
+		s.ticker.Stop()
+	}
+
+	s.isDragging = false
+	s.isDismissing = false
+
+	s.targetExtent = clampFloat(target, 0, s.availableHeight)
+
+	s.spring = animation.NewSpringSimulation(
+		animation.IOSSpring(),
+		s.currentExtent,
+		velocity,
+		s.targetExtent,
+	)
+
+	s.startSpring(nil)
+}
+
+func (s *bottomSheetState) animateToDismiss(result any) {
+	if !s.metricsReady {
+		if s.onDismiss != nil {
+			s.onDismiss(result)
+		}
+		return
+	}
+
+	if s.ticker != nil {
+		s.ticker.Stop()
+	}
+
+	s.spring = animation.NewSpringSimulation(
+		animation.IOSSpring(),
+		s.currentExtent,
+		0,
+		0,
+	)
+
+	s.startSpring(result)
+}
+
+func (s *bottomSheetState) startSpring(dismissResult any) {
+	lastTime := animation.Now()
+	s.ticker = animation.NewTicker(func(elapsed time.Duration) {
+		if s.spring == nil {
+			s.ticker.Stop()
+			return
+		}
+		now := animation.Now()
+		dt := now.Sub(lastTime).Seconds()
+		lastTime = now
+
+		done := s.spring.Step(dt)
+		newExtent := s.spring.Position()
+		s.SetState(func() {
+			s.currentExtent = clampFloat(newExtent, 0, s.availableHeight)
+		})
+		s.updateProgress()
+
+		if done {
+			s.ticker.Stop()
+			if s.currentExtent <= 0.5 && s.isDismissing {
+				if s.onDismiss != nil {
+					s.onDismiss(dismissResult)
+				}
+			}
+		}
+	})
+	s.ticker.Start()
+}
+
+func (s *bottomSheetState) updateProgress() {
+	if s.controller == nil {
+		return
+	}
+	maxExtent := s.maxSnapHeight()
+	if maxExtent <= 0 {
+		s.controller.setProgress(0)
+		return
+	}
+	s.controller.setProgress(s.currentExtent / maxExtent)
+}
+
+func (s *bottomSheetState) maxSnapHeight() float64 {
+	if len(s.snapHeights) == 0 {
+		if s.contentSized {
+			return s.targetExtent
+		}
+		return 0
+	}
+	return s.snapHeights[len(s.snapHeights)-1]
+}
+
+func (s *bottomSheetState) onDragStart(_ DragStartDetails) {
+	if !s.enableDrag || !s.metricsReady {
+		return
+	}
+	if s.ticker != nil {
+		s.ticker.Stop()
+	}
+	s.spring = nil
+	s.isDragging = true
+}
+
+func (s *bottomSheetState) onDragUpdate(d DragUpdateDetails) {
+	if !s.isDragging || !s.metricsReady {
+		return
+	}
+	delta := -d.PrimaryDelta
+	s.SetState(func() {
+		s.currentExtent = clampFloat(s.currentExtent+delta, 0, s.availableHeight)
+	})
+	s.updateProgress()
+}
+
+func (s *bottomSheetState) onDragEnd(d DragEndDetails) {
+	if !s.isDragging || !s.metricsReady {
+		return
+	}
+	s.isDragging = false
+
+	velocity := -d.PrimaryVelocity
+	target := s.findTargetSnap(s.currentExtent, velocity)
+
+	if target <= 0 {
+		s.isDismissing = true
+		s.animateToDismiss(nil)
+		return
+	}
+
+	s.animateTo(target, velocity)
+}
+
+// findTargetSnap determines which snap point to animate to after a drag ends.
+// Returns 0 to indicate the sheet should dismiss.
+// The decision considers current position, drag velocity, and snap behavior thresholds.
+func (s *bottomSheetState) findTargetSnap(position, velocity float64) float64 {
+	if len(s.snapHeights) == 0 {
+		return 0
+	}
+
+	minSnap := s.snapHeights[0]
+	dismissThreshold := minSnap * s.snapBehavior.DismissFactor
+
+	// Below dismiss threshold with downward or no velocity: dismiss
+	if position < dismissThreshold && velocity <= 0 {
+		return 0
+	}
+
+	// Fast downward fling near bottom: dismiss
+	if velocity < -s.snapBehavior.MinFlingVelocity && position < minSnap*0.8 {
+		return 0
+	}
+
+	// High velocity: snap in direction of travel
+	if math.Abs(velocity) > s.snapBehavior.SnapVelocityThreshold {
+		if velocity < 0 {
+			// Dragging down: go to next lower snap (but not dismiss)
+			lower := s.nextLowerSnap(position)
+			if lower <= 0 {
+				return minSnap
+			}
+			return lower
+		}
+		// Dragging up: go to next higher snap
+		return s.nextHigherSnap(position)
+	}
+
+	// Low velocity: snap to nearest point
+	return s.nearestSnap(position)
+}
+
+func (s *bottomSheetState) nextLowerSnap(position float64) float64 {
+	for i := len(s.snapHeights) - 1; i >= 0; i-- {
+		if s.snapHeights[i] < position-1 {
+			return s.snapHeights[i]
+		}
+	}
+	return 0
+}
+
+func (s *bottomSheetState) nextHigherSnap(position float64) float64 {
+	for i := 0; i < len(s.snapHeights); i++ {
+		if s.snapHeights[i] > position+1 {
+			return s.snapHeights[i]
+		}
+	}
+	return s.snapHeights[len(s.snapHeights)-1]
+}
+
+func (s *bottomSheetState) nearestSnap(position float64) float64 {
+	nearest := s.snapHeights[0]
+	minDist := math.Abs(position - nearest)
+	for _, snap := range s.snapHeights[1:] {
+		dist := math.Abs(position - snap)
+		if dist < minDist {
+			minDist = dist
+			nearest = snap
+		}
+	}
+	return nearest
+}
+
+func (s *bottomSheetState) shouldStartHandleDrag(totalDelta float64) bool {
+	return s.enableDrag
+}
+
+// shouldStartDrag decides whether to accept a vertical drag gesture.
+// For content-aware mode, this coordinates with scrollable content:
+// - If content is scrolled down, let the scroll view handle the gesture
+// - If at scroll top and dragging down, the sheet takes over
+// - If sheet is not at max height and dragging up, the sheet expands first
+func (s *bottomSheetState) shouldStartDrag(totalDelta float64) bool {
+	if !s.enableDrag {
+		return false
+	}
+	dragMode := s.resolveDragMode()
+	if dragMode == DragModeSheet {
+		return true
+	}
+	if dragMode != DragModeContentAware {
+		return false
+	}
+
+	// No scrollable registered: sheet always handles drags
+	if s.scrollController == nil {
+		return true
+	}
+	// Content is scrolled down: let scroll view handle the gesture
+	if s.scrollOffset > 0 {
+		return false
+	}
+	// At scroll top, dragging down: sheet takes over to collapse/dismiss
+	if totalDelta > 0 {
+		return true
+	}
+	// Dragging up: sheet expands if not at max height, else scroll view handles
+	maxExtent := s.maxSnapHeight()
+	return s.currentExtent < maxExtent
+}
+
+func (s *bottomSheetState) registerScrollable(controller *ScrollController) func() {
+	if controller == nil {
+		return func() {}
+	}
+	if s.scrollRemove != nil {
+		s.scrollRemove()
+	}
+	s.scrollController = controller
+	s.scrollOffset = controller.Offset()
+	s.scrollRemove = controller.AddListener(func() {
+		s.scrollOffset = controller.Offset()
+	})
+	return func() {
+		if s.scrollRemove != nil {
+			s.scrollRemove()
+			s.scrollRemove = nil
+		}
+		if s.scrollController == controller {
+			s.scrollController = nil
+		}
+	}
+}
+
+func (s *bottomSheetState) buildHandle() core.Widget {
+	handle := Container{
+		Width:        s.theme.HandleWidth,
+		Height:       s.theme.HandleHeight,
+		Color:        s.theme.HandleColor,
+		BorderRadius: s.theme.HandleHeight / 2,
+	}
+
+	return Row{
+		MainAxisSize:      MainAxisSizeMax,
+		MainAxisAlignment: MainAxisAlignmentCenter,
+		Children: []core.Widget{
+			Padding{
+				Padding: layout.EdgeInsets{
+					Top:    s.theme.HandleTopPadding,
+					Bottom: s.theme.HandleBottomPadding,
+				},
+				Child: handle,
+			},
+		},
+	}
+}
+
+// bottomSheetScopeBuilder wraps the content builder in a scope widget.
+// This allows the builder to be called with a context that has the scope as an ancestor.
+type bottomSheetScopeBuilder struct {
+	controller *BottomSheetController
+	builder    func(core.BuildContext) core.Widget
+}
+
+func (b bottomSheetScopeBuilder) CreateElement() core.Element {
+	return core.NewStatelessElement(b, nil)
+}
+
+func (b bottomSheetScopeBuilder) Key() any {
+	return nil
+}
+
+func (b bottomSheetScopeBuilder) Build(ctx core.BuildContext) core.Widget {
+	return bottomSheetScope{
+		controller: b.controller,
+		child: bottomSheetContentBuilder{
+			builder: b.builder,
+		},
+	}
+}
+
+// bottomSheetContentBuilder calls the user's builder.
+type bottomSheetContentBuilder struct {
+	builder func(core.BuildContext) core.Widget
+}
+
+func (b bottomSheetContentBuilder) CreateElement() core.Element {
+	return core.NewStatelessElement(b, nil)
+}
+
+func (b bottomSheetContentBuilder) Key() any {
+	return nil
+}
+
+func (b bottomSheetContentBuilder) Build(ctx core.BuildContext) core.Widget {
+	if b.builder == nil {
+		return nil
+	}
+	return b.builder(ctx)
+}
+
+// bottomSheetScope is an InheritedWidget that provides the controller to descendants.
+type bottomSheetScope struct {
+	controller *BottomSheetController
+	child      core.Widget
+}
+
+func (b bottomSheetScope) CreateElement() core.Element {
+	return core.NewInheritedElement(b, nil)
+}
+
+func (b bottomSheetScope) Key() any {
+	return nil
+}
+
+func (b bottomSheetScope) ChildWidget() core.Widget {
+	return b.child
+}
+
+func (b bottomSheetScope) UpdateShouldNotify(oldWidget core.InheritedWidget) bool {
+	if old, ok := oldWidget.(bottomSheetScope); ok {
+		return b.controller != old.controller
+	}
+	return true
+}
+
+func (b bottomSheetScope) UpdateShouldNotifyDependent(oldWidget core.InheritedWidget, aspects map[any]struct{}) bool {
+	return b.UpdateShouldNotify(oldWidget)
+}
+
+var bottomSheetScopeType = reflect.TypeFor[bottomSheetScope]()
+
+// BottomSheetScope provides access to the bottom sheet controller from within sheet content.
+// Use BottomSheetScope.Of(ctx).Close(result) to dismiss the sheet with animation.
+type BottomSheetScope struct{}
+
+// Of returns the BottomSheetController for the enclosing bottom sheet.
+// Returns nil if not inside a bottom sheet or if the sheet has no controller.
+func (BottomSheetScope) Of(ctx core.BuildContext) *BottomSheetController {
+	inherited := ctx.DependOnInherited(bottomSheetScopeType, nil)
+	if inherited == nil {
+		return nil
+	}
+	if scope, ok := inherited.(bottomSheetScope); ok {
+		return scope.controller
+	}
+	return nil
+}
+
+// BottomSheetScrollable bridges a scroll controller to the enclosing bottom sheet
+// so the sheet can coordinate content-aware dragging.
+//
+// Example:
+//
+//	return widgets.BottomSheetScrollable{
+//		Builder: func(controller *widgets.ScrollController) core.Widget {
+//			return widgets.ListView{
+//				Controller: controller,
+//				Children:   items,
+//			}
+//		},
+//	}
+type BottomSheetScrollable struct {
+	Controller *ScrollController
+	Builder    func(controller *ScrollController) core.Widget
+}
+
+func (b BottomSheetScrollable) CreateElement() core.Element {
+	return core.NewStatefulElement(b, nil)
+}
+
+func (b BottomSheetScrollable) Key() any {
+	return nil
+}
+
+func (b BottomSheetScrollable) CreateState() core.State {
+	return &bottomSheetScrollableState{}
+}
+
+type bottomSheetScrollableState struct {
+	core.StateBase
+	controller *ScrollController
+	unregister func()
+	registered bool
+}
+
+func (s *bottomSheetScrollableState) InitState() {
+	widget := s.Element().Widget().(BottomSheetScrollable)
+	s.ensureController(widget)
+	s.registered = false
+}
+
+func (s *bottomSheetScrollableState) DidUpdateWidget(oldWidget core.StatefulWidget) {
+	widget := s.Element().Widget().(BottomSheetScrollable)
+	old := oldWidget.(BottomSheetScrollable)
+	if widget.Controller != old.Controller {
+		s.detach()
+		s.ensureController(widget)
+		s.registered = false
+	}
+}
+
+func (s *bottomSheetScrollableState) Dispose() {
+	s.detach()
+}
+
+func (s *bottomSheetScrollableState) Build(ctx core.BuildContext) core.Widget {
+	widget := s.Element().Widget().(BottomSheetScrollable)
+	if !s.registered {
+		s.register(ctx)
+	}
+	if widget.Builder == nil {
+		return nil
+	}
+	return widget.Builder(s.controller)
+}
+
+func (s *bottomSheetScrollableState) ensureController(widget BottomSheetScrollable) {
+	s.controller = widget.Controller
+	if s.controller == nil {
+		s.controller = &ScrollController{}
+	}
+}
+
+func (s *bottomSheetScrollableState) register(ctx core.BuildContext) {
+	if s.controller == nil {
+		return
+	}
+	scope := BottomSheetScope{}.Of(ctx)
+	if scope == nil {
+		return
+	}
+	s.unregister = scope.registerScrollableInternal(s.controller)
+	s.registered = true
+}
+
+func (s *bottomSheetScrollableState) detach() {
+	if s.unregister != nil {
+		s.unregister()
+		s.unregister = nil
+	}
+	s.registered = false
+}

--- a/pkg/widgets/bottom_sheet_drag.go
+++ b/pkg/widgets/bottom_sheet_drag.go
@@ -1,0 +1,280 @@
+package widgets
+
+import (
+	"math"
+	"time"
+
+	"github.com/go-drift/drift/pkg/core"
+	"github.com/go-drift/drift/pkg/gestures"
+	"github.com/go-drift/drift/pkg/graphics"
+	"github.com/go-drift/drift/pkg/layout"
+)
+
+// sheetDragRegion handles vertical drag gestures with conditional acceptance.
+type sheetDragRegion struct {
+	Child       core.Widget
+	ShouldStart func(totalDelta float64) bool
+	OnStart     func(DragStartDetails)
+	OnUpdate    func(DragUpdateDetails)
+	OnEnd       func(DragEndDetails)
+	OnCancel    func()
+}
+
+func (s sheetDragRegion) CreateElement() core.Element {
+	return core.NewRenderObjectElement(s, nil)
+}
+
+func (s sheetDragRegion) Key() any {
+	return nil
+}
+
+func (s sheetDragRegion) ChildWidget() core.Widget {
+	return s.Child
+}
+
+func (s sheetDragRegion) CreateRenderObject(ctx core.BuildContext) layout.RenderObject {
+	r := &renderSheetDragRegion{}
+	r.SetSelf(r)
+	r.configure(s)
+	return r
+}
+
+func (s sheetDragRegion) UpdateRenderObject(ctx core.BuildContext, renderObject layout.RenderObject) {
+	if r, ok := renderObject.(*renderSheetDragRegion); ok {
+		r.configure(s)
+		r.MarkNeedsPaint()
+	}
+}
+
+// renderSheetDragRegion is the render object for sheetDragRegion.
+// It wraps a child and intercepts pointer events for the drag recognizer.
+type renderSheetDragRegion struct {
+	layout.RenderBoxBase
+	child      layout.RenderBox
+	recognizer *conditionalVerticalDragRecognizer
+}
+
+func (r *renderSheetDragRegion) SetChild(child layout.RenderObject) {
+	setParentOnChild(r.child, nil)
+	r.child = setChildFromRenderObject(child)
+	setParentOnChild(r.child, r)
+}
+
+func (r *renderSheetDragRegion) VisitChildren(visitor func(layout.RenderObject)) {
+	if r.child != nil {
+		visitor(r.child)
+	}
+}
+
+func (r *renderSheetDragRegion) PerformLayout() {
+	constraints := r.Constraints()
+	if r.child == nil {
+		r.SetSize(constraints.Constrain(graphics.Size{}))
+		return
+	}
+	r.child.Layout(constraints, true)
+	r.SetSize(r.child.Size())
+	r.child.SetParentData(&layout.BoxParentData{})
+}
+
+func (r *renderSheetDragRegion) Paint(ctx *layout.PaintContext) {
+	if r.child != nil {
+		ctx.PaintChildWithLayer(r.child, graphics.Offset{})
+	}
+}
+
+func (r *renderSheetDragRegion) HitTest(position graphics.Offset, result *layout.HitTestResult) bool {
+	if !withinBounds(position, r.Size()) {
+		return false
+	}
+	if r.child != nil {
+		r.child.HitTest(position, result)
+	}
+	result.Add(r)
+	return true
+}
+
+func (r *renderSheetDragRegion) HandlePointer(event gestures.PointerEvent) {
+	if r.recognizer == nil {
+		return
+	}
+	if event.Phase == gestures.PointerPhaseDown {
+		r.recognizer.AddPointer(event)
+		return
+	}
+	r.recognizer.HandleEvent(event)
+}
+
+func (r *renderSheetDragRegion) configure(s sheetDragRegion) {
+	if r.recognizer == nil {
+		r.recognizer = newConditionalVerticalDragRecognizer(gestures.DefaultArena)
+	}
+	r.recognizer.ShouldAccept = s.ShouldStart
+	r.recognizer.OnStart = s.OnStart
+	r.recognizer.OnUpdate = s.OnUpdate
+	r.recognizer.OnEnd = s.OnEnd
+	r.recognizer.OnCancel = s.OnCancel
+}
+
+// conditionalVerticalDragRecognizer is a gesture recognizer for vertical drags
+// that can conditionally accept or reject based on the drag direction and context.
+// This enables content-aware dragging where the sheet decides whether to handle
+// a gesture or let it pass through to scrollable content.
+type conditionalVerticalDragRecognizer struct {
+	Arena        *gestures.GestureArena
+	ShouldAccept func(totalDelta float64) bool // called when drag exceeds slop to decide acceptance
+	OnStart      func(DragStartDetails)
+	OnUpdate     func(DragUpdateDetails)
+	OnEnd        func(DragEndDetails)
+	OnCancel     func()
+
+	pointer  int64           // current pointer being tracked
+	start    graphics.Offset // initial touch position
+	last     graphics.Offset // most recent touch position
+	lastTime time.Time       // timestamp of last update (for velocity)
+	velocity float64         // smoothed vertical velocity in pixels/second
+	slop     float64         // minimum distance before recognizing a drag
+	accepted bool            // true after winning gesture arena
+	reject   bool            // true if gesture was rejected
+	started  bool            // true after OnStart has been called
+}
+
+func newConditionalVerticalDragRecognizer(arena *gestures.GestureArena) *conditionalVerticalDragRecognizer {
+	return &conditionalVerticalDragRecognizer{Arena: arena}
+}
+
+func (c *conditionalVerticalDragRecognizer) AddPointer(event gestures.PointerEvent) {
+	if c.Arena == nil {
+		return
+	}
+	c.pointer = event.PointerID
+	c.start = event.Position
+	c.last = event.Position
+	c.lastTime = time.Now()
+	c.velocity = 0
+	c.slop = gestures.DefaultTouchSlop
+	c.accepted = false
+	c.reject = false
+	c.started = false
+	c.Arena.Add(event.PointerID, c)
+	c.Arena.Hold(event.PointerID, c)
+}
+
+func (c *conditionalVerticalDragRecognizer) HandleEvent(event gestures.PointerEvent) {
+	if event.PointerID != c.pointer || c.reject {
+		return
+	}
+	switch event.Phase {
+	case gestures.PointerPhaseMove:
+		c.handleMove(event)
+	case gestures.PointerPhaseUp:
+		c.handleUp(event)
+	case gestures.PointerPhaseCancel:
+		c.handleCancel()
+	}
+}
+
+// handleMove processes pointer move events, determining whether to accept the gesture
+// and tracking velocity for fling detection.
+func (c *conditionalVerticalDragRecognizer) handleMove(event gestures.PointerEvent) {
+	now := time.Now()
+	dt := now.Sub(c.lastTime).Seconds()
+
+	// Calculate total movement from start
+	total := graphics.Offset{X: event.Position.X - c.start.X, Y: event.Position.Y - c.start.Y}
+	primary := math.Abs(total.Y)
+	orthogonal := math.Abs(total.X)
+
+	// Gesture recognition: decide to accept or reject once slop is exceeded
+	if !c.accepted {
+		if primary > c.slop && primary >= orthogonal {
+			// Vertical movement dominant: ask callback if we should accept
+			shouldAccept := true
+			if c.ShouldAccept != nil {
+				shouldAccept = c.ShouldAccept(total.Y)
+			}
+			if shouldAccept {
+				c.Arena.Resolve(c.pointer, c)
+			} else {
+				// Callback rejected: let other recognizers handle it
+				c.reject = true
+				c.Arena.Reject(c.pointer, c)
+				return
+			}
+		} else if orthogonal > c.slop {
+			// Horizontal movement dominant: reject (likely a horizontal scroll)
+			c.reject = true
+			c.Arena.Reject(c.pointer, c)
+			return
+		}
+	}
+
+	// Update velocity using exponential smoothing for stable fling detection
+	delta := graphics.Offset{X: event.Position.X - c.last.X, Y: event.Position.Y - c.last.Y}
+	if dt > 0 {
+		inst := delta.Y / dt
+		c.velocity = c.velocity*0.8 + inst*0.2
+	}
+
+	// Dispatch update if gesture is accepted
+	if c.accepted {
+		c.ensureStarted()
+		if c.OnUpdate != nil {
+			c.OnUpdate(DragUpdateDetails{
+				Position:     event.Position,
+				Delta:        delta,
+				PrimaryDelta: delta.Y,
+			})
+		}
+	}
+
+	c.last = event.Position
+	c.lastTime = now
+}
+
+func (c *conditionalVerticalDragRecognizer) handleUp(event gestures.PointerEvent) {
+	if c.accepted {
+		if c.OnEnd != nil {
+			c.OnEnd(DragEndDetails{
+				Position:        event.Position,
+				Velocity:        graphics.Offset{X: 0, Y: c.velocity},
+				PrimaryVelocity: c.velocity,
+			})
+		}
+	} else {
+		c.Arena.Reject(c.pointer, c)
+	}
+}
+
+func (c *conditionalVerticalDragRecognizer) handleCancel() {
+	if c.accepted && c.OnCancel != nil {
+		c.OnCancel()
+	}
+	c.reject = true
+	c.Arena.Reject(c.pointer, c)
+}
+
+func (c *conditionalVerticalDragRecognizer) AcceptGesture(pointerID int64) {
+	if pointerID != c.pointer || c.reject {
+		return
+	}
+	c.accepted = true
+	c.ensureStarted()
+}
+
+func (c *conditionalVerticalDragRecognizer) RejectGesture(pointerID int64) {
+	if pointerID != c.pointer {
+		return
+	}
+	c.reject = true
+}
+
+func (c *conditionalVerticalDragRecognizer) ensureStarted() {
+	if c.started {
+		return
+	}
+	c.started = true
+	if c.OnStart != nil {
+		c.OnStart(DragStartDetails{Position: c.start})
+	}
+}

--- a/pkg/widgets/bottom_sheet_layout.go
+++ b/pkg/widgets/bottom_sheet_layout.go
@@ -1,0 +1,442 @@
+package widgets
+
+import (
+	"math"
+
+	"github.com/go-drift/drift/pkg/core"
+	"github.com/go-drift/drift/pkg/graphics"
+	"github.com/go-drift/drift/pkg/layout"
+)
+
+// sheetMetrics reports layout info for bottom sheet state.
+type sheetMetrics struct {
+	AvailableHeight float64
+	ScreenHeight    float64
+	TopInset        float64
+	BottomInset     float64
+	ContentHeight   float64
+}
+
+// bottomSheetPositioner positions the sheet at the bottom of the screen.
+type bottomSheetPositioner struct {
+	Extent       float64
+	TopInset     float64
+	BottomInset  float64
+	ContentSized bool
+	Child        core.Widget
+	OnMetrics    func(sheetMetrics)
+}
+
+func (b bottomSheetPositioner) CreateElement() core.Element {
+	return core.NewRenderObjectElement(b, nil)
+}
+
+func (b bottomSheetPositioner) Key() any {
+	return nil
+}
+
+func (b bottomSheetPositioner) ChildWidget() core.Widget {
+	return b.Child
+}
+
+func (b bottomSheetPositioner) CreateRenderObject(ctx core.BuildContext) layout.RenderObject {
+	r := &renderBottomSheetPositioner{
+		extent:       b.Extent,
+		topInset:     b.TopInset,
+		bottomInset:  b.BottomInset,
+		contentSized: b.ContentSized,
+		onMetrics:    b.OnMetrics,
+	}
+	r.SetSelf(r)
+	return r
+}
+
+func (b bottomSheetPositioner) UpdateRenderObject(ctx core.BuildContext, renderObject layout.RenderObject) {
+	if r, ok := renderObject.(*renderBottomSheetPositioner); ok {
+		r.extent = b.Extent
+		r.topInset = b.TopInset
+		r.bottomInset = b.BottomInset
+		r.contentSized = b.ContentSized
+		r.onMetrics = b.OnMetrics
+		r.MarkNeedsLayout()
+	}
+}
+
+// renderBottomSheetPositioner is the render object for bottomSheetPositioner.
+// It fills the available space (typically the full screen) and positions
+// its child sheet at the bottom, with the visible portion determined by extent.
+type renderBottomSheetPositioner struct {
+	layout.RenderBoxBase
+	child        layout.RenderBox
+	extent       float64 // current visible extent in pixels (above safe area)
+	topInset     float64 // top safe area inset
+	bottomInset  float64 // bottom safe area inset
+	contentSized bool    // if true, child determines its own height
+	onMetrics    func(sheetMetrics)
+
+	// Computed during layout for hit testing
+	sheetTop    float64 // Y position of sheet's top edge
+	sheetHeight float64 // visible height of sheet
+}
+
+func (r *renderBottomSheetPositioner) SetChild(child layout.RenderObject) {
+	if r.child != nil {
+		if s, ok := r.child.(interface{ SetParent(layout.RenderObject) }); ok {
+			s.SetParent(nil)
+		}
+	}
+	if child == nil {
+		r.child = nil
+		return
+	}
+	if box, ok := child.(layout.RenderBox); ok {
+		r.child = box
+		if s, ok := r.child.(interface{ SetParent(layout.RenderObject) }); ok {
+			s.SetParent(r)
+		}
+	}
+}
+
+func (r *renderBottomSheetPositioner) VisitChildren(visitor func(layout.RenderObject)) {
+	if r.child != nil {
+		visitor(r.child)
+	}
+}
+
+// PerformLayout positions the sheet child at the bottom of the screen.
+// The sheet's visible height is determined by extent (for snap-point sheets)
+// or by the child's intrinsic size (for content-sized sheets).
+// The sheet background extends into the bottom safe area, but content does not.
+func (r *renderBottomSheetPositioner) PerformLayout() {
+	constraints := r.Constraints()
+	screenWidth := constraints.MaxWidth
+	screenHeight := constraints.MaxHeight
+	if screenWidth <= 0 {
+		screenWidth = constraints.MinWidth
+	}
+	if screenHeight <= 0 {
+		screenHeight = constraints.MinHeight
+	}
+
+	// Available height for sheet content (excluding safe areas)
+	availableHeight := math.Max(0, screenHeight-r.topInset-r.bottomInset)
+
+	// Layout the child to determine its size
+	childHeight := 0.0
+	if r.child != nil {
+		var childConstraints layout.Constraints
+		if r.contentSized {
+			// Content-sized: let child determine height up to available space
+			childConstraints = layout.Constraints{
+				MinWidth:  screenWidth,
+				MaxWidth:  screenWidth,
+				MinHeight: 0,
+				MaxHeight: availableHeight + r.bottomInset,
+			}
+		} else {
+			// Snap-point: force child to exact height (extent + bottom inset for background)
+			extent := clampFloat(r.extent, 0, availableHeight)
+			sheetHeight := extent + r.bottomInset
+			childConstraints = layout.Constraints{
+				MinWidth:  screenWidth,
+				MaxWidth:  screenWidth,
+				MinHeight: sheetHeight,
+				MaxHeight: sheetHeight,
+			}
+		}
+		r.child.Layout(childConstraints, true)
+		childHeight = r.child.Size().Height
+	}
+
+	// Report metrics back to sheet state (used for snap height calculations)
+	contentHeight := 0.0
+	if childHeight > 0 {
+		contentHeight = math.Max(0, childHeight-r.bottomInset)
+	}
+	if r.onMetrics != nil {
+		r.onMetrics(sheetMetrics{
+			AvailableHeight: availableHeight,
+			ScreenHeight:    screenHeight,
+			TopInset:        r.topInset,
+			BottomInset:     r.bottomInset,
+			ContentHeight:   contentHeight,
+		})
+	}
+
+	// Calculate visible portion of the sheet
+	visibleExtent := clampFloat(r.extent, 0, availableHeight)
+	visibleHeight := visibleExtent + r.bottomInset
+	if visibleExtent <= 0 {
+		visibleHeight = 0
+	}
+	if r.contentSized && childHeight > 0 {
+		// For content-sized sheets, clamp to actual content height
+		maxExtent := math.Max(0, childHeight-r.bottomInset)
+		visibleExtent = clampFloat(r.extent, 0, maxExtent)
+		visibleHeight = visibleExtent
+		if visibleExtent > 0 {
+			visibleHeight = visibleExtent + r.bottomInset
+		}
+		if visibleHeight > childHeight {
+			visibleHeight = childHeight
+		}
+	}
+
+	// Position the child at the bottom of the screen
+	if r.child != nil {
+		yOffset := screenHeight - visibleHeight
+		if yOffset < r.topInset {
+			yOffset = r.topInset
+		}
+		if r.contentSized && childHeight > 0 && childHeight < visibleHeight {
+			yOffset = screenHeight - childHeight
+		}
+		r.sheetTop = yOffset
+		r.sheetHeight = visibleHeight
+		r.child.SetParentData(&layout.BoxParentData{
+			Offset: graphics.Offset{X: 0, Y: yOffset},
+		})
+	}
+
+	r.SetSize(graphics.Size{Width: screenWidth, Height: screenHeight})
+}
+
+func (r *renderBottomSheetPositioner) Paint(ctx *layout.PaintContext) {
+	if r.child == nil {
+		return
+	}
+	parentData := r.child.ParentData().(*layout.BoxParentData)
+	ctx.PaintChildWithLayer(r.child, parentData.Offset)
+}
+
+func (r *renderBottomSheetPositioner) HitTest(position graphics.Offset, result *layout.HitTestResult) bool {
+	if r.child == nil {
+		return false
+	}
+	if position.Y < r.sheetTop || position.Y > r.sheetTop+r.sheetHeight {
+		return false
+	}
+	local := graphics.Offset{X: position.X, Y: position.Y - r.sheetTop}
+	r.child.HitTest(local, result)
+	result.Add(r)
+	return true
+}
+
+// bottomSheetBody lays out the handle and content inside the sheet.
+type bottomSheetBody struct {
+	Handle       core.Widget
+	Content      core.Widget
+	BottomInset  float64
+	Background   graphics.Color
+	BorderRadius float64
+	ContentSized bool
+}
+
+func (b bottomSheetBody) CreateElement() core.Element {
+	return core.NewRenderObjectElement(b, nil)
+}
+
+func (b bottomSheetBody) Key() any {
+	return nil
+}
+
+func (b bottomSheetBody) ChildrenWidgets() []core.Widget {
+	handle := b.Handle
+	if handle == nil {
+		handle = SizedBox{}
+	}
+	content := b.Content
+	if content == nil {
+		content = SizedBox{}
+	}
+	return []core.Widget{handle, content}
+}
+
+func (b bottomSheetBody) CreateRenderObject(ctx core.BuildContext) layout.RenderObject {
+	r := &renderBottomSheetBody{
+		bottomInset:  b.BottomInset,
+		background:   b.Background,
+		borderRadius: b.BorderRadius,
+		contentSized: b.ContentSized,
+	}
+	r.SetSelf(r)
+	return r
+}
+
+func (b bottomSheetBody) UpdateRenderObject(ctx core.BuildContext, renderObject layout.RenderObject) {
+	if r, ok := renderObject.(*renderBottomSheetBody); ok {
+		r.bottomInset = b.BottomInset
+		r.background = b.Background
+		r.borderRadius = b.BorderRadius
+		r.contentSized = b.ContentSized
+		r.MarkNeedsLayout()
+		r.MarkNeedsPaint()
+	}
+}
+
+// renderBottomSheetBody is the render object for bottomSheetBody.
+// It arranges the drag handle above the content and draws the sheet background.
+// The content viewport height adjusts based on the current sheet extent,
+// which allows scroll views inside to compute their scroll range correctly.
+type renderBottomSheetBody struct {
+	layout.RenderBoxBase
+	handle       layout.RenderBox // optional drag handle at top
+	content      layout.RenderBox // main sheet content
+	bottomInset  float64          // space reserved for bottom safe area
+	background   graphics.Color   // sheet background color
+	borderRadius float64          // top corner radius
+	contentSized bool             // if true, content determines sheet height
+}
+
+func (r *renderBottomSheetBody) SetChildren(children []layout.RenderObject) {
+	setParentOnChild(r.handle, nil)
+	setParentOnChild(r.content, nil)
+	r.handle = nil
+	r.content = nil
+	if len(children) > 0 {
+		if box, ok := children[0].(layout.RenderBox); ok {
+			r.handle = box
+			setParentOnChild(r.handle, r)
+		}
+	}
+	if len(children) > 1 {
+		if box, ok := children[1].(layout.RenderBox); ok {
+			r.content = box
+			setParentOnChild(r.content, r)
+		}
+	}
+}
+
+func (r *renderBottomSheetBody) VisitChildren(visitor func(layout.RenderObject)) {
+	if r.handle != nil {
+		visitor(r.handle)
+	}
+	if r.content != nil {
+		visitor(r.content)
+	}
+}
+
+// PerformLayout arranges the handle and content vertically within the sheet.
+// The layout is: [handle] [content] [bottom inset padding].
+// For content-sized sheets, the sheet height is derived from content.
+// For snap-point sheets, the content is forced to fill the available space,
+// ensuring scroll views get the correct viewport height for their scroll extent.
+func (r *renderBottomSheetBody) PerformLayout() {
+	constraints := r.Constraints()
+	sheetWidth := constraints.MaxWidth
+	sheetHeight := constraints.MaxHeight
+	if sheetWidth <= 0 {
+		sheetWidth = constraints.MinWidth
+	}
+	if sheetHeight <= 0 {
+		sheetHeight = constraints.MinHeight
+	}
+
+	// Layout handle first (intrinsic height)
+	handleHeight := 0.0
+	if r.handle != nil {
+		r.handle.Layout(layout.Constraints{
+			MinWidth:  sheetWidth,
+			MaxWidth:  sheetWidth,
+			MinHeight: 0,
+			MaxHeight: sheetHeight,
+		}, true)
+		handleHeight = r.handle.Size().Height
+		r.handle.SetParentData(&layout.BoxParentData{Offset: graphics.Offset{X: 0, Y: 0}})
+	}
+
+	// Content-sized: let content determine its height, then set sheet size
+	if r.contentSized {
+		maxContentHeight := math.Max(0, sheetHeight-handleHeight-r.bottomInset)
+		contentHeight := 0.0
+		if r.content != nil {
+			r.content.Layout(layout.Constraints{
+				MinWidth:  sheetWidth,
+				MaxWidth:  sheetWidth,
+				MinHeight: 0,
+				MaxHeight: maxContentHeight,
+			}, true)
+			contentHeight = r.content.Size().Height
+			r.content.SetParentData(&layout.BoxParentData{
+				Offset: graphics.Offset{X: 0, Y: handleHeight},
+			})
+		}
+		sheetHeight = clampFloat(handleHeight+contentHeight+r.bottomInset, 0, constraints.MaxHeight)
+		r.SetSize(graphics.Size{Width: sheetWidth, Height: sheetHeight})
+		return
+	}
+
+	// Snap-point mode: force content to fill remaining space.
+	// This ensures scroll views get viewport height = currentExtent - handleHeight,
+	// allowing their scroll extent to grow as the sheet expands.
+	contentHeight := math.Max(0, sheetHeight-handleHeight-r.bottomInset)
+	if r.content != nil {
+		r.content.Layout(layout.Constraints{
+			MinWidth:  sheetWidth,
+			MaxWidth:  sheetWidth,
+			MinHeight: contentHeight,
+			MaxHeight: contentHeight,
+		}, true)
+		r.content.SetParentData(&layout.BoxParentData{
+			Offset: graphics.Offset{X: 0, Y: handleHeight},
+		})
+	}
+
+	r.SetSize(graphics.Size{Width: sheetWidth, Height: sheetHeight})
+}
+
+func (r *renderBottomSheetBody) Paint(ctx *layout.PaintContext) {
+	size := r.Size()
+	if size.Width <= 0 || size.Height <= 0 {
+		return
+	}
+
+	radius := r.borderRadius
+	if radius < 0 {
+		radius = 0
+	}
+	rect := graphics.RectFromLTWH(0, 0, size.Width, size.Height)
+	rrect := graphics.RRectFromRectAndRadius(rect, graphics.CircularRadius(radius))
+
+	ctx.Canvas.Save()
+	ctx.Canvas.ClipRRect(rrect)
+	ctx.PushClipRect(rect)
+
+	if r.background != 0 {
+		paint := graphics.DefaultPaint()
+		paint.Color = r.background
+		ctx.Canvas.DrawRRect(rrect, paint)
+	}
+
+	if r.handle != nil {
+		ctx.PaintChildWithLayer(r.handle, getChildOffset(r.handle))
+	}
+	if r.content != nil {
+		ctx.PaintChildWithLayer(r.content, getChildOffset(r.content))
+	}
+
+	ctx.PopClipRect()
+	ctx.Canvas.Restore()
+}
+
+func (r *renderBottomSheetBody) HitTest(position graphics.Offset, result *layout.HitTestResult) bool {
+	if !withinBounds(position, r.Size()) {
+		return false
+	}
+	if r.handle != nil {
+		offset := getChildOffset(r.handle)
+		local := graphics.Offset{X: position.X - offset.X, Y: position.Y - offset.Y}
+		if r.handle.HitTest(local, result) {
+			return true
+		}
+	}
+	if r.content != nil {
+		offset := getChildOffset(r.content)
+		local := graphics.Offset{X: position.X - offset.X, Y: position.Y - offset.Y}
+		if r.content.HitTest(local, result) {
+			return true
+		}
+	}
+	result.Add(r)
+	return true
+}

--- a/pkg/widgets/bottom_sheet_test.go
+++ b/pkg/widgets/bottom_sheet_test.go
@@ -1,0 +1,178 @@
+package widgets
+
+import (
+	"testing"
+
+	"github.com/go-drift/drift/pkg/graphics"
+)
+
+func TestNormalizeSnapPoints_Empty(t *testing.T) {
+	result := NormalizeSnapPoints(nil)
+	if len(result) != 1 {
+		t.Fatalf("Expected 1 snap point, got %d", len(result))
+	}
+	if result[0].FractionalHeight != 1.0 {
+		t.Errorf("Expected default snap point at 1.0, got %f", result[0].FractionalHeight)
+	}
+}
+
+func TestNormalizeSnapPoints_ClampsValues(t *testing.T) {
+	points := []SnapPoint{
+		{FractionalHeight: 0.05, Name: "too-low"},
+		{FractionalHeight: 1.5, Name: "too-high"},
+		{FractionalHeight: 0.5, Name: "valid"},
+	}
+	result := NormalizeSnapPoints(points)
+	if len(result) != 3 {
+		t.Fatalf("Expected 3 snap points, got %d", len(result))
+	}
+	if result[0].FractionalHeight != 0.1 {
+		t.Errorf("Expected first snap point at 0.1, got %f", result[0].FractionalHeight)
+	}
+	if result[1].FractionalHeight != 0.5 {
+		t.Errorf("Expected second snap point at 0.5, got %f", result[1].FractionalHeight)
+	}
+	if result[2].FractionalHeight != 1.0 {
+		t.Errorf("Expected third snap point at 1.0, got %f", result[2].FractionalHeight)
+	}
+}
+
+func TestNormalizeSnapPoints_SortsAndDedups(t *testing.T) {
+	points := []SnapPoint{
+		{FractionalHeight: 0.9, Name: "full"},
+		{FractionalHeight: 0.3, Name: "small"},
+		{FractionalHeight: 0.5, Name: "half"},
+		{FractionalHeight: 0.5, Name: "duplicate"},
+	}
+	result := NormalizeSnapPoints(points)
+	if len(result) != 3 {
+		t.Fatalf("Expected 3 snap points, got %d", len(result))
+	}
+	if result[0].FractionalHeight != 0.3 {
+		t.Errorf("Expected first snap point at 0.3, got %f", result[0].FractionalHeight)
+	}
+	if result[1].FractionalHeight != 0.5 {
+		t.Errorf("Expected second snap point at 0.5, got %f", result[1].FractionalHeight)
+	}
+	if result[2].FractionalHeight != 0.9 {
+		t.Errorf("Expected third snap point at 0.9, got %f", result[2].FractionalHeight)
+	}
+	if result[1].Name != "half" {
+		t.Errorf("Expected first 0.5 snap to be preserved, got %q", result[1].Name)
+	}
+}
+
+func TestValidateInitialSnap(t *testing.T) {
+	points := []SnapPoint{{FractionalHeight: 0.5}, {FractionalHeight: 0.9}}
+	if ValidateInitialSnap(0, points) != 0 {
+		t.Error("ValidateInitialSnap(0) should return 0")
+	}
+	if ValidateInitialSnap(1, points) != 1 {
+		t.Error("ValidateInitialSnap(1) should return 1")
+	}
+	if ValidateInitialSnap(-1, points) != 0 {
+		t.Error("ValidateInitialSnap(-1) should return 0")
+	}
+	if ValidateInitialSnap(5, points) != 0 {
+		t.Error("ValidateInitialSnap(5) should return 0")
+	}
+}
+
+func TestClampFloat(t *testing.T) {
+	tests := []struct {
+		value, min, max, expected float64
+	}{
+		{0.5, 0.0, 1.0, 0.5},
+		{-0.5, 0.0, 1.0, 0.0},
+		{1.5, 0.0, 1.0, 1.0},
+		{0.0, 0.0, 1.0, 0.0},
+		{1.0, 0.0, 1.0, 1.0},
+	}
+	for _, tt := range tests {
+		result := clampFloat(tt.value, tt.min, tt.max)
+		if result != tt.expected {
+			t.Errorf("clampFloat(%f, %f, %f) = %f, want %f",
+				tt.value, tt.min, tt.max, result, tt.expected)
+		}
+	}
+}
+
+func TestDefaultBottomSheetTheme(t *testing.T) {
+	theme := DefaultBottomSheetTheme()
+	if theme.BorderRadius != 16 {
+		t.Errorf("Expected BorderRadius 16, got %f", theme.BorderRadius)
+	}
+	if theme.HandleWidth != 32 {
+		t.Errorf("Expected HandleWidth 32, got %f", theme.HandleWidth)
+	}
+	if theme.HandleHeight != 4 {
+		t.Errorf("Expected HandleHeight 4, got %f", theme.HandleHeight)
+	}
+	if theme.HandleTopPadding != 8 {
+		t.Errorf("Expected HandleTopPadding 8, got %f", theme.HandleTopPadding)
+	}
+	if theme.HandleBottomPadding != 8 {
+		t.Errorf("Expected HandleBottomPadding 8, got %f", theme.HandleBottomPadding)
+	}
+	if theme.BackgroundColor != graphics.ColorWhite {
+		t.Errorf("Expected BackgroundColor to be ColorWhite")
+	}
+}
+
+func TestSnapPointPresets(t *testing.T) {
+	if SnapThird.FractionalHeight != 0.33 {
+		t.Errorf("SnapThird should be 0.33, got %f", SnapThird.FractionalHeight)
+	}
+	if SnapThird.Name != "third" {
+		t.Errorf("SnapThird.Name should be 'third', got %q", SnapThird.Name)
+	}
+
+	if SnapHalf.FractionalHeight != 0.5 {
+		t.Errorf("SnapHalf should be 0.5, got %f", SnapHalf.FractionalHeight)
+	}
+	if SnapHalf.Name != "half" {
+		t.Errorf("SnapHalf.Name should be 'half', got %q", SnapHalf.Name)
+	}
+
+	if SnapFull.FractionalHeight != 1.0 {
+		t.Errorf("SnapFull should be 1.0, got %f", SnapFull.FractionalHeight)
+	}
+	if SnapFull.Name != "full" {
+		t.Errorf("SnapFull.Name should be 'full', got %q", SnapFull.Name)
+	}
+}
+
+func TestNormalizeSnapBehavior_Defaults(t *testing.T) {
+	behavior := normalizeSnapBehavior(SnapBehavior{})
+	if behavior.DismissFactor <= 0 {
+		t.Errorf("DismissFactor should be > 0")
+	}
+	if behavior.MinFlingVelocity <= 0 {
+		t.Errorf("MinFlingVelocity should be > 0")
+	}
+	if behavior.SnapVelocityThreshold <= 0 {
+		t.Errorf("SnapVelocityThreshold should be > 0")
+	}
+}
+
+func TestBottomSheetState_FindTargetSnap(t *testing.T) {
+	state := &bottomSheetState{
+		snapHeights:  []float64{200, 400, 600},
+		snapBehavior: normalizeSnapBehavior(SnapBehavior{}),
+	}
+
+	result := state.findTargetSnap(450, 0)
+	if result != 400 {
+		t.Errorf("findTargetSnap(450, 0) = %f, want 400", result)
+	}
+
+	result = state.findTargetSnap(450, 800)
+	if result != 600 {
+		t.Errorf("findTargetSnap(450, 800) = %f, want 600", result)
+	}
+
+	result = state.findTargetSnap(250, -800)
+	if result != 200 {
+		t.Errorf("findTargetSnap(250, -800) = %f, want 200", result)
+	}
+}

--- a/showcase/bottom_sheets.go
+++ b/showcase/bottom_sheets.go
@@ -1,0 +1,403 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/go-drift/drift/pkg/core"
+	"github.com/go-drift/drift/pkg/drift"
+	"github.com/go-drift/drift/pkg/graphics"
+	"github.com/go-drift/drift/pkg/layout"
+	"github.com/go-drift/drift/pkg/navigation"
+	"github.com/go-drift/drift/pkg/theme"
+	"github.com/go-drift/drift/pkg/widgets"
+)
+
+// buildBottomSheetsPage demonstrates bottom sheets with various configurations.
+func buildBottomSheetsPage(ctx core.BuildContext) core.Widget {
+	_, colors, _ := theme.UseTheme(ctx)
+
+	return demoPage(ctx, "Bottom Sheets",
+		// Section: Basic Bottom Sheet
+		sectionTitle("Basic Bottom Sheet", colors),
+		widgets.VSpace(12),
+		widgets.Text{Content: "Slides up from bottom, drag to dismiss:", Style: labelStyle(colors)},
+		widgets.VSpace(8),
+		theme.ButtonOf(ctx, "Show Bottom Sheet", func() {
+			showBasicBottomSheet(ctx)
+		}),
+		widgets.VSpace(24),
+
+		// Section: Bottom Sheet with Snap Points
+		sectionTitle("Snap Points", colors),
+		widgets.VSpace(12),
+		widgets.Text{Content: "Drag handle to half or full screen, scroll content:", Style: labelStyle(colors)},
+		widgets.VSpace(8),
+		theme.ButtonOf(ctx, "Show Multi-Snap Sheet", func() {
+			showSnapPointsBottomSheet(ctx)
+		}),
+		widgets.VSpace(24),
+
+		// Section: Bottom Sheet with Result
+		sectionTitle("Selection Sheet", colors),
+		widgets.VSpace(12),
+		widgets.Text{Content: "Returns a value when dismissed:", Style: labelStyle(colors)},
+		widgets.VSpace(8),
+		theme.ButtonOf(ctx, "Show Selection Sheet", func() {
+			showSelectionBottomSheet(ctx)
+		}),
+		widgets.VSpace(24),
+
+		// Section: Non-Dismissible Sheet
+		sectionTitle("Non-Dismissible", colors),
+		widgets.VSpace(12),
+		widgets.Text{Content: "Barrier tap disabled, must use button:", Style: labelStyle(colors)},
+		widgets.VSpace(8),
+		theme.ButtonOf(ctx, "Show Required Action Sheet", func() {
+			showNonDismissibleBottomSheet(ctx)
+		}),
+		widgets.VSpace(24),
+
+		// Section: No Handle
+		sectionTitle("Custom Appearance", colors),
+		widgets.VSpace(12),
+		widgets.Text{Content: "Without drag handle:", Style: labelStyle(colors)},
+		widgets.VSpace(8),
+		theme.ButtonOf(ctx, "Show Sheet Without Handle", func() {
+			showNoHandleBottomSheet(ctx)
+		}),
+		widgets.VSpace(40),
+	)
+}
+
+// showBasicBottomSheet displays a simple bottom sheet with drag-to-dismiss.
+func showBasicBottomSheet(ctx core.BuildContext) {
+	colors := theme.ColorsOf(ctx)
+
+	navigation.ShowModalBottomSheet(ctx, func(ctx core.BuildContext) core.Widget {
+		return widgets.Padding{
+			Padding: layout.EdgeInsetsAll(24),
+			Child: widgets.Column{
+				MainAxisSize:       widgets.MainAxisSizeMin,
+				CrossAxisAlignment: widgets.CrossAxisAlignmentStart,
+				Children: []core.Widget{
+					widgets.Text{
+						Content: "Bottom Sheet",
+						Style: graphics.TextStyle{
+							Color:      colors.OnSurface,
+							FontSize:   20,
+							FontWeight: graphics.FontWeightBold,
+						},
+					},
+					widgets.VSpace(12),
+					widgets.Text{
+						Content: "This is a modal bottom sheet. You can drag it down to dismiss, or tap the barrier behind it.",
+						Wrap:    true,
+						Style: graphics.TextStyle{
+							Color:    colors.OnSurfaceVariant,
+							FontSize: 14,
+						},
+					},
+					widgets.VSpace(20),
+					widgets.Row{
+						MainAxisAlignment: widgets.MainAxisAlignmentCenter,
+						Children: []core.Widget{
+							theme.ButtonOf(ctx, "Close", func() {
+								widgets.BottomSheetScope{}.Of(ctx).Close(nil)
+							}),
+						},
+					},
+				},
+			},
+		}
+	})
+}
+
+// showSnapPointsBottomSheet displays a bottom sheet with snap points and scrollable content.
+func showSnapPointsBottomSheet(ctx core.BuildContext) {
+	colors := theme.ColorsOf(ctx)
+
+	navigation.ShowModalBottomSheet(ctx, func(ctx core.BuildContext) core.Widget {
+		// Build items list with header included
+		items := make([]core.Widget, 0, 32)
+
+		// Add header as first items in the list
+		items = append(items,
+			widgets.Padding{
+				Padding: layout.EdgeInsets{Left: 24, Right: 24, Top: 24},
+				Child: widgets.Text{
+					Content: "Scrollable List",
+					Style: graphics.TextStyle{
+						Color:      colors.OnSurface,
+						FontSize:   20,
+						FontWeight: graphics.FontWeightBold,
+					},
+				},
+			},
+			widgets.Padding{
+				Padding: layout.EdgeInsets{Left: 24, Right: 24, Bottom: 16},
+				Child: widgets.Text{
+					Content: "Drag the handle to resize. Scroll the list below.",
+					Wrap:    true,
+					Style: graphics.TextStyle{
+						Color:    colors.OnSurfaceVariant,
+						FontSize: 14,
+					},
+				},
+			},
+		)
+
+		// Add list items
+		for i := range 30 {
+			items = append(items, sheetItemRow(colors,
+				fmt.Sprintf("Item %d", i+1),
+				fmt.Sprintf("Description for item %d", i+1)))
+		}
+
+		return widgets.BottomSheetScrollable{
+			Builder: func(controller *widgets.ScrollController) core.Widget {
+				return widgets.ListView{
+					Controller: controller,
+					Padding:    layout.EdgeInsets{Left: 24, Right: 24, Bottom: 24},
+					Physics:    widgets.BouncingScrollPhysics{},
+					Children:   items,
+				}
+			},
+		}
+	},
+		navigation.WithSnapPoints(widgets.SnapHalf, widgets.SnapFull),
+		navigation.WithInitialSnapPoint(0),
+		navigation.WithDragMode(widgets.DragModeContentAware),
+	)
+}
+
+// showSelectionBottomSheet displays a bottom sheet that returns a selected value.
+func showSelectionBottomSheet(ctx core.BuildContext) {
+	colors := theme.ColorsOf(ctx)
+
+	go func() {
+		result := <-navigation.ShowModalBottomSheet(ctx, func(ctx core.BuildContext) core.Widget {
+			return widgets.Padding{
+				Padding: layout.EdgeInsetsAll(24),
+				Child: widgets.Column{
+					MainAxisSize:       widgets.MainAxisSizeMin,
+					CrossAxisAlignment: widgets.CrossAxisAlignmentStretch,
+					Children: []core.Widget{
+						widgets.Text{
+							Content: "Select an Option",
+							Style: graphics.TextStyle{
+								Color:      colors.OnSurface,
+								FontSize:   20,
+								FontWeight: graphics.FontWeightBold,
+							},
+						},
+						widgets.VSpace(16),
+						sheetSelectionItem(ctx, colors, "Option A", "First choice", "A"),
+						widgets.VSpace(8),
+						sheetSelectionItem(ctx, colors, "Option B", "Second choice", "B"),
+						widgets.VSpace(8),
+						sheetSelectionItem(ctx, colors, "Option C", "Third choice", "C"),
+						widgets.VSpace(12),
+						widgets.Row{
+							MainAxisAlignment: widgets.MainAxisAlignmentCenter,
+							Children: []core.Widget{
+								theme.ButtonOf(ctx, "Cancel", func() {
+									widgets.BottomSheetScope{}.Of(ctx).Close(nil)
+								}).WithColor(colors.SurfaceVariant, colors.OnSurfaceVariant),
+							},
+						},
+					},
+				},
+			}
+		},
+			navigation.WithSnapPoints(widgets.SnapPoint{FractionalHeight: 0.5, Name: "selection"}),
+		)
+
+		// Show toast with result
+		if result != nil {
+			drift.Dispatch(func() {
+				showToast(ctx, "Selected: "+result.(string))
+			})
+		} else {
+			drift.Dispatch(func() {
+				showToast(ctx, "Selection cancelled")
+			})
+		}
+	}()
+}
+
+// showNonDismissibleBottomSheet displays a bottom sheet that can't be dismissed by tapping the barrier.
+func showNonDismissibleBottomSheet(ctx core.BuildContext) {
+	colors := theme.ColorsOf(ctx)
+
+	navigation.ShowModalBottomSheet(ctx, func(ctx core.BuildContext) core.Widget {
+		return widgets.Padding{
+			Padding: layout.EdgeInsetsAll(24),
+			Child: widgets.Column{
+				MainAxisSize:       widgets.MainAxisSizeMin,
+				CrossAxisAlignment: widgets.CrossAxisAlignmentStart,
+				Children: []core.Widget{
+					widgets.Text{
+						Content: "Required Action",
+						Style: graphics.TextStyle{
+							Color:      colors.Error,
+							FontSize:   20,
+							FontWeight: graphics.FontWeightBold,
+						},
+					},
+					widgets.VSpace(12),
+					widgets.Text{
+						Content: "This sheet requires you to take action. Tapping the barrier does NOT dismiss it. You must use the button below.",
+						Wrap:    true,
+						Style: graphics.TextStyle{
+							Color:    colors.OnSurfaceVariant,
+							FontSize: 14,
+						},
+					},
+					widgets.VSpace(20),
+					widgets.Row{
+						MainAxisAlignment: widgets.MainAxisAlignmentCenter,
+						Children: []core.Widget{
+							theme.ButtonOf(ctx, "Cancel", func() {
+								widgets.BottomSheetScope{}.Of(ctx).Close(nil)
+							}).WithColor(colors.SurfaceVariant, colors.OnSurfaceVariant),
+							widgets.HSpace(12),
+							theme.ButtonOf(ctx, "Confirm", func() {
+								widgets.BottomSheetScope{}.Of(ctx).Close("confirmed")
+							}),
+						},
+					},
+				},
+			},
+		}
+	},
+		navigation.WithBarrierDismissible(false),
+		navigation.WithDragEnabled(false),
+	)
+}
+
+// showNoHandleBottomSheet displays a bottom sheet without a drag handle.
+func showNoHandleBottomSheet(ctx core.BuildContext) {
+	colors := theme.ColorsOf(ctx)
+
+	navigation.ShowModalBottomSheet(ctx, func(ctx core.BuildContext) core.Widget {
+		return widgets.Padding{
+			Padding: layout.EdgeInsetsAll(24),
+			Child: widgets.Column{
+				MainAxisSize:       widgets.MainAxisSizeMin,
+				CrossAxisAlignment: widgets.CrossAxisAlignmentStart,
+				Children: []core.Widget{
+					widgets.Text{
+						Content: "No Handle",
+						Style: graphics.TextStyle{
+							Color:      colors.OnSurface,
+							FontSize:   20,
+							FontWeight: graphics.FontWeightBold,
+						},
+					},
+					widgets.VSpace(12),
+					widgets.Text{
+						Content: "This sheet has no drag handle at the top. You can still drag it to dismiss, or tap the barrier.",
+						Wrap:    true,
+						Style: graphics.TextStyle{
+							Color:    colors.OnSurfaceVariant,
+							FontSize: 14,
+						},
+					},
+					widgets.VSpace(20),
+					widgets.Row{
+						MainAxisAlignment: widgets.MainAxisAlignmentCenter,
+						Children: []core.Widget{
+							theme.ButtonOf(ctx, "Close", func() {
+								widgets.BottomSheetScope{}.Of(ctx).Close(nil)
+							}),
+						},
+					},
+				},
+			},
+		}
+	},
+		navigation.WithHandle(false),
+	)
+}
+
+// sheetItemRow creates a list item row for the bottom sheet demo.
+func sheetItemRow(colors theme.ColorScheme, title, subtitle string) core.Widget {
+	return widgets.Padding{
+		Padding: layout.EdgeInsetsSymmetric(0, 8),
+		Child: widgets.Row{
+			CrossAxisAlignment: widgets.CrossAxisAlignmentCenter,
+			Children: []core.Widget{
+				widgets.Container{
+					Width:        40,
+					Height:       40,
+					Color:        colors.SurfaceVariant,
+					BorderRadius: 20,
+				},
+				widgets.HSpace(12),
+				widgets.Column{
+					CrossAxisAlignment: widgets.CrossAxisAlignmentStart,
+					MainAxisSize:       widgets.MainAxisSizeMin,
+					Children: []core.Widget{
+						widgets.Text{
+							Content: title,
+							Style: graphics.TextStyle{
+								Color:      colors.OnSurface,
+								FontSize:   16,
+								FontWeight: graphics.FontWeightMedium,
+							},
+						},
+						widgets.Text{
+							Content: subtitle,
+							Style: graphics.TextStyle{
+								Color:    colors.OnSurfaceVariant,
+								FontSize: 12,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// sheetSelectionItem creates a tappable selection item for the bottom sheet demo.
+func sheetSelectionItem(ctx core.BuildContext, colors theme.ColorScheme, title, subtitle, value string) core.Widget {
+	return widgets.GestureDetector{
+		OnTap: func() {
+			widgets.BottomSheetScope{}.Of(ctx).Close(value)
+		},
+		Child: widgets.Container{
+			Color:        colors.SurfaceVariant,
+			BorderRadius: 8,
+			Padding:      layout.EdgeInsetsAll(12),
+			Child: widgets.Row{
+				CrossAxisAlignment: widgets.CrossAxisAlignmentCenter,
+				Children: []core.Widget{
+					widgets.Expanded{
+						Child: widgets.Column{
+							CrossAxisAlignment: widgets.CrossAxisAlignmentStart,
+							MainAxisSize:       widgets.MainAxisSizeMin,
+							Children: []core.Widget{
+								widgets.Text{
+									Content: title,
+									Style: graphics.TextStyle{
+										Color:      colors.OnSurface,
+										FontSize:   16,
+										FontWeight: graphics.FontWeightMedium,
+									},
+								},
+								widgets.Text{
+									Content: subtitle,
+									Style: graphics.TextStyle{
+										Color:    colors.OnSurfaceVariant,
+										FontSize: 12,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/showcase/registry.go
+++ b/showcase/registry.go
@@ -66,6 +66,7 @@ var demos = []Demo{
 	{"/scroll", "Scrolling", "Scrollable lists with physics", CategoryLayout, "icon-scroll.svg", buildScrollPage},
 	{"/tabs", "Tabs", "Bottom tab navigation", CategoryWidgets, "icon-navigation.svg", buildTabsPage},
 	{"/overlays", "Overlays", "Modals, dialogs, and toasts", CategoryWidgets, "icon-navigation.svg", buildOverlaysPage},
+	{"/bottom-sheets", "Bottom Sheets", "Drag-to-dismiss sheets", CategoryWidgets, "icon-navigation.svg", buildBottomSheetsPage},
 
 	// Media demos
 	{"/camera", "Camera", "Photo capture and gallery access", CategoryMedia, "icon-camera.svg", buildCameraPage},

--- a/website-docs/guides/navigation.md
+++ b/website-docs/guides/navigation.md
@@ -145,6 +145,57 @@ Return data when popping a route:
 nav.Pop("selected_item_id")
 ```
 
+## Modal Bottom Sheets
+
+Use `ShowModalBottomSheet` to present a bottom sheet and await a result.
+
+```go
+result := <-navigation.ShowModalBottomSheet(ctx, func(ctx core.BuildContext) core.Widget {
+    return widgets.Padding{
+        Padding: layout.EdgeInsetsAll(24),
+        Child: widgets.Column{
+            MainAxisSize: widgets.MainAxisSizeMin,
+            Children: []core.Widget{
+                widgets.Text{Content: "Select an option"},
+                theme.ButtonOf(ctx, "Option A", func() {
+                    widgets.BottomSheetScope{}.Of(ctx).Close("A")
+                }),
+            },
+        },
+    }
+})
+```
+
+### Snap Points and Drag Modes
+
+```go
+navigation.ShowModalBottomSheet(
+    ctx,
+    func(ctx core.BuildContext) core.Widget { return sheetContent() },
+    navigation.WithSnapPoints(widgets.SnapHalf, widgets.SnapFull),
+    navigation.WithInitialSnapPoint(0),
+    navigation.WithDragMode(widgets.DragModeContentAware),
+)
+```
+
+### Scrollable Content
+
+For scrollable content, wrap the list in `BottomSheetScrollable` so dragging and
+scrolling are coordinated:
+
+```go
+navigation.ShowModalBottomSheet(ctx, func(ctx core.BuildContext) core.Widget {
+    return widgets.BottomSheetScrollable{
+        Builder: func(controller *widgets.ScrollController) core.Widget {
+            return widgets.ListView{
+                Controller: controller,
+                Children:   items,
+            }
+        },
+    }
+})
+```
+
 Handle results by using a callback pattern:
 
 ```go

--- a/website-docs/guides/overlay.md
+++ b/website-docs/guides/overlay.md
@@ -189,6 +189,73 @@ func showDialog(ctx core.BuildContext) {
 - Removes both entries when the route is popped
 - Handles the case where overlay isn't ready yet (defers insertion)
 
+## Bottom Sheets
+
+Bottom sheets are built on overlays and modal routes, and can be presented using
+the navigation helper `ShowModalBottomSheet`.
+
+```go
+result := <-navigation.ShowModalBottomSheet(ctx, func(ctx core.BuildContext) core.Widget {
+    return widgets.Padding{
+        Padding: layout.EdgeInsetsAll(24),
+        Child: widgets.Text{Content: "Bottom sheet content"},
+    }
+})
+```
+
+### Snap Points and Available Height
+
+Snap points are defined as fractions of **available height** (screen height minus
+safe area insets).
+
+```go
+navigation.ShowModalBottomSheet(
+    ctx,
+    func(ctx core.BuildContext) core.Widget { return sheetContent() },
+    navigation.WithSnapPoints(widgets.SnapHalf, widgets.SnapFull),
+    navigation.WithInitialSnapPoint(0),
+)
+```
+
+### Content-Aware Dragging
+
+Use `BottomSheetScrollable` to coordinate scrollables with sheet dragging.
+This allows the sheet to drag when the scroll view is at the top, and otherwise
+lets the list consume the gesture.
+
+```go
+navigation.ShowModalBottomSheet(ctx, func(ctx core.BuildContext) core.Widget {
+    return widgets.BottomSheetScrollable{
+        Builder: func(controller *widgets.ScrollController) core.Widget {
+            return widgets.ListView{
+                Controller: controller,
+                Children:   items,
+            }
+        },
+    }
+},
+    navigation.WithSnapPoints(widgets.SnapHalf, widgets.SnapFull),
+    navigation.WithDragMode(widgets.DragModeContentAware),
+)
+```
+
+### Programmatic Control
+
+Use `BottomSheetScope` from inside the sheet content:
+
+```go
+navigation.ShowModalBottomSheet(ctx, func(ctx core.BuildContext) core.Widget {
+    return widgets.Column{
+        Children: []core.Widget{
+            widgets.Text{Content: "Sheet"},
+            theme.ButtonOf(ctx, "Close", func() {
+                widgets.BottomSheetScope{}.Of(ctx).Close(nil)
+            }),
+        },
+    }
+})
+```
+
 ## Navigator Integration
 
 The `Navigator` widget automatically wraps its content in an `Overlay`. This means:


### PR DESCRIPTION
- Add BottomSheet widget with snap points, drag-to-dismiss, and scrim
- Implement BottomSheetRoute for navigator-based sheet presentation
- Support dynamic content sizing with scroll-aware viewport
- Add theme support via BottomSheetThemeData
- Include showcase demo and documentation